### PR TITLE
controllers: test with sqlite

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -20,6 +20,9 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
+      - name: Install Atlas CLI
+        run: |
+          curl -sSf https://atlasgo.sh | sh
       - name: Generate
         run: make generate manifests chart-manifests
         shell: bash


### PR DESCRIPTION
Reduce the need for mocks in most local tests by running tests against a `sqlite` database.

Probably less useful in a production setting since the SQLite database would need to be in a volume mounted into the controller manager, but can be done. 