### PR TITLE
controllers: support disposeDevDB flag

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -88,6 +88,25 @@ jobs:
 
           # Expect the new column to be present.
           kubectl exec $POD_MYSQL -- mysql -uroot -h 127.0.0.1 -ppass -e "SHOW COLUMNS FROM myapp.users LIKE 'phone';"
+
+          # Expect the devdb deployment is scaled to 1.
+          kubectl get deployment atlasschema-mysql-atlas-dev-db -o=jsonpath='{.spec.replicas}' | grep -q '1'
+
+          # SET DISPOSE_DEVDB to true
+          kubectl set env -n atlas-operator-system deployment/atlas-operator-controller-manager DISPOSE_DEVDB=true
+
+          # Reset database resources
+          kubectl delete pods -l app=mysql
+          kubectl wait --for condition=ready pods -l app=mysql --timeout=60s
+
+          # Apply the desired schema and wait for it to be ready.
+          kubectl delete -f config/integration/schema
+          kubectl apply -f config/integration/schema
+          kubectl wait --for=condition=ready --timeout=120s atlasschemas --all
+
+          # Expect the devdb deployment is scaled to 0.
+          kubectl get deployment atlasschema-mysql-atlas-dev-db -o=jsonpath='{.spec.replicas}' | grep -q '0'
+
       - name: Reset database resources
         run: |
           kubectl delete pods -l app=mysql

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -89,11 +89,11 @@ jobs:
           # Expect the new column to be present.
           kubectl exec $POD_MYSQL -- mysql -uroot -h 127.0.0.1 -ppass -e "SHOW COLUMNS FROM myapp.users LIKE 'phone';"
 
-          # Expect the devdb deployment is scaled to 0.
-          kubectl get deployment atlasschema-mysql-atlas-dev-db -o=jsonpath='{.spec.replicas}' | grep -q '0'
+          # Expect the devdb deployment is scaled to 1.
+          kubectl get deployment atlasschema-mysql-atlas-dev-db -o=jsonpath='{.spec.replicas}' | grep -q '1'
 
           # SET PREWARM_DEVDB to true
-          kubectl set env -n atlas-operator-system deployment/atlas-operator-controller-manager PREWARM_DEVDB=true
+          kubectl set env -n atlas-operator-system deployment/atlas-operator-controller-manager PREWARM_DEVDB=false
 
           # Reset database resources
           kubectl delete pods -l app=mysql
@@ -104,8 +104,8 @@ jobs:
           kubectl apply -f config/integration/schema
           kubectl wait --for=condition=ready --timeout=120s atlasschemas --all
 
-          # Expect the devdb deployment is scaled to 1.
-          kubectl get deployment atlasschema-mysql-atlas-dev-db -o=jsonpath='{.spec.replicas}' | grep -q '1'
+          # Expect the devdb deployment is scaled to 0.
+          kubectl get deployment atlasschema-mysql-atlas-dev-db -o=jsonpath='{.spec.replicas}' | grep -q '0'
 
       - name: Reset database resources
         run: |

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -89,11 +89,11 @@ jobs:
           # Expect the new column to be present.
           kubectl exec $POD_MYSQL -- mysql -uroot -h 127.0.0.1 -ppass -e "SHOW COLUMNS FROM myapp.users LIKE 'phone';"
 
-          # Expect the devdb deployment is scaled to 1.
-          kubectl get deployment atlasschema-mysql-atlas-dev-db -o=jsonpath='{.spec.replicas}' | grep -q '1'
+          # Expect the devdb deployment is scaled to 0.
+          kubectl get deployment atlasschema-mysql-atlas-dev-db -o=jsonpath='{.spec.replicas}' | grep -q '0'
 
-          # SET DISPOSE_DEVDB to true
-          kubectl set env -n atlas-operator-system deployment/atlas-operator-controller-manager DISPOSE_DEVDB=true
+          # SET PREWARM_DEVDB to true
+          kubectl set env -n atlas-operator-system deployment/atlas-operator-controller-manager PREWARM_DEVDB=true
 
           # Reset database resources
           kubectl delete pods -l app=mysql
@@ -104,8 +104,8 @@ jobs:
           kubectl apply -f config/integration/schema
           kubectl wait --for=condition=ready --timeout=120s atlasschemas --all
 
-          # Expect the devdb deployment is scaled to 0.
-          kubectl get deployment atlasschema-mysql-atlas-dev-db -o=jsonpath='{.spec.replicas}' | grep -q '0'
+          # Expect the devdb deployment is scaled to 1.
+          kubectl get deployment atlasschema-mysql-atlas-dev-db -o=jsonpath='{.spec.replicas}' | grep -q '1'
 
       - name: Reset database resources
         run: |

--- a/charts/atlas-operator/templates/deployment.yaml
+++ b/charts/atlas-operator/templates/deployment.yaml
@@ -45,6 +45,11 @@ spec:
           {{- toYaml .Values.resources | nindent 12 }}
         securityContext:
           {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+        env:
+        {{- if .Values.disposeDevDB }}
+        - name: DISPOSE_DEVDB
+          value: "true"
+        {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/atlas-operator/templates/deployment.yaml
+++ b/charts/atlas-operator/templates/deployment.yaml
@@ -46,8 +46,8 @@ spec:
         securityContext:
           {{- toYaml .Values.containerSecurityContext | nindent 12 }}
         env:
-        {{- if .Values.disposeDevDB }}
-        - name: DISPOSE_DEVDB
+        {{- if .Values.prewarmDevDB }}
+        - name: PREWARM_DEVDB
           value: "true"
         {{- end }}
       {{- with .Values.imagePullSecrets }}

--- a/charts/atlas-operator/values.yaml
+++ b/charts/atlas-operator/values.yaml
@@ -43,4 +43,4 @@ affinity: {}
 
 # By default, the operator will recreate devdb pods after migration
 # Set this to true to keep the devdb pods around.
-disposeDevDB: false
+prewarmDevDB: true

--- a/charts/atlas-operator/values.yaml
+++ b/charts/atlas-operator/values.yaml
@@ -40,3 +40,7 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# By default, the operator will recreate devdb pods after migration
+# Set this to true to keep the devdb pods around.
+disposeDevDB: false

--- a/controllers/atlasschema_controller.go
+++ b/controllers/atlasschema_controller.go
@@ -58,6 +58,7 @@ type (
 		configMapWatcher *watch.ResourceWatcher
 		secretWatcher    *watch.ResourceWatcher
 		recorder         record.EventRecorder
+		disposeDevDB     bool
 	}
 	// managedData contains information about the managed database and its desired state.
 	managedData struct {
@@ -73,7 +74,7 @@ type (
 	}
 )
 
-func NewAtlasSchemaReconciler(mgr Manager, execPath string) *AtlasSchemaReconciler {
+func NewAtlasSchemaReconciler(mgr Manager, execPath string, disposeDevDB bool) *AtlasSchemaReconciler {
 	return &AtlasSchemaReconciler{
 		Client:           mgr.GetClient(),
 		scheme:           mgr.GetScheme(),
@@ -81,6 +82,7 @@ func NewAtlasSchemaReconciler(mgr Manager, execPath string) *AtlasSchemaReconcil
 		configMapWatcher: watch.New(),
 		secretWatcher:    watch.New(),
 		recorder:         mgr.GetEventRecorderFor("atlasschema-controller"),
+		disposeDevDB:     disposeDevDB,
 	}
 }
 

--- a/controllers/atlasschema_controller.go
+++ b/controllers/atlasschema_controller.go
@@ -58,7 +58,7 @@ type (
 		configMapWatcher *watch.ResourceWatcher
 		secretWatcher    *watch.ResourceWatcher
 		recorder         record.EventRecorder
-		disposeDevDB     bool
+		prewarmDevDB     bool
 	}
 	// managedData contains information about the managed database and its desired state.
 	managedData struct {
@@ -74,7 +74,7 @@ type (
 	}
 )
 
-func NewAtlasSchemaReconciler(mgr Manager, execPath string, disposeDevDB bool) *AtlasSchemaReconciler {
+func NewAtlasSchemaReconciler(mgr Manager, execPath string, prewarmDevDB bool) *AtlasSchemaReconciler {
 	return &AtlasSchemaReconciler{
 		Client:           mgr.GetClient(),
 		scheme:           mgr.GetScheme(),
@@ -82,7 +82,7 @@ func NewAtlasSchemaReconciler(mgr Manager, execPath string, disposeDevDB bool) *
 		configMapWatcher: watch.New(),
 		secretWatcher:    watch.New(),
 		recorder:         mgr.GetEventRecorderFor("atlasschema-controller"),
-		disposeDevDB:     disposeDevDB,
+		prewarmDevDB:     prewarmDevDB,
 	}
 }
 

--- a/controllers/atlasschema_controller_test.go
+++ b/controllers/atlasschema_controller_test.go
@@ -111,7 +111,7 @@ func TestReconcile_Reconcile(t *testing.T) {
 		Spec:       dbv1alpha1.AtlasSchemaSpec{},
 	}
 	h, reconcile := newRunner(func(mgr Manager, name string) reconcile.Reconciler {
-		return NewAtlasSchemaReconciler(mgr, name, false)
+		return NewAtlasSchemaReconciler(mgr, name, true)
 	}, func(cb *fake.ClientBuilder) {
 		cb.WithObjects(obj)
 	})

--- a/controllers/atlasschema_controller_test.go
+++ b/controllers/atlasschema_controller_test.go
@@ -45,6 +45,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 const (
@@ -109,7 +110,9 @@ func TestReconcile_Reconcile(t *testing.T) {
 		ObjectMeta: meta,
 		Spec:       dbv1alpha1.AtlasSchemaSpec{},
 	}
-	h, reconcile := newRunner(NewAtlasSchemaReconciler, func(cb *fake.ClientBuilder) {
+	h, reconcile := newRunner(func(mgr Manager, name string) reconcile.Reconciler {
+		return NewAtlasSchemaReconciler(mgr, name, false)
+	}, func(cb *fake.ClientBuilder) {
 		cb.WithObjects(obj)
 	})
 	assert := func(except ctrl.Result, ready bool, reason, msg string) {

--- a/controllers/devdb.go
+++ b/controllers/devdb.go
@@ -46,18 +46,36 @@ const (
 
 // cleanUp clean up any resources created by the controller
 func (r *AtlasSchemaReconciler) cleanUp(ctx context.Context, sc *dbv1alpha1.AtlasSchema) {
-	pods := &corev1.PodList{}
-	err := r.List(ctx, pods, client.MatchingLabels(map[string]string{
-		labelInstance: nameDevDB(sc.ObjectMeta).Name,
-	}))
-	if err != nil {
-		r.recorder.Eventf(sc, corev1.EventTypeWarning, "CleanUpDevDB", "Error listing devDB pods: %v", err)
-	}
-	for _, p := range pods.Items {
-		if err := r.Delete(ctx, &p); err != nil {
-			r.recorder.Eventf(sc, corev1.EventTypeWarning, "CleanUpDevDB", "Error deleting devDB pod %s: %v", p.Name, err)
+	// If disposeDevDB is true, scale down the deployment to 0
+	// Otherwise, delete pods to clean up
+	if r.disposeDevDB {
+		deploy := &appsv1.Deployment{}
+		key := nameDevDB(sc.ObjectMeta)
+		err := r.Get(ctx, key, deploy)
+		if err != nil {
+			r.recorder.Eventf(sc, corev1.EventTypeWarning, "CleanUpDevDB", "Error getting devDB deployment: %v", err)
+			return
+		}
+		deploy.Spec.Replicas = new(int32)
+		if err := r.Update(ctx, deploy); err != nil {
+			r.recorder.Eventf(sc, corev1.EventTypeWarning, "CleanUpDevDB", "Error scaling down devDB deployment: %v", err)
+		}
+	} else {
+		pods := &corev1.PodList{}
+		err := r.List(ctx, pods, client.MatchingLabels(map[string]string{
+			labelInstance: nameDevDB(sc.ObjectMeta).Name,
+		}))
+		if err != nil {
+			r.recorder.Eventf(sc, corev1.EventTypeWarning, "CleanUpDevDB", "Error listing devDB pods: %v", err)
+		}
+
+		for _, p := range pods.Items {
+			if err := r.Delete(ctx, &p); err != nil {
+				r.recorder.Eventf(sc, corev1.EventTypeWarning, "CleanUpDevDB", "Error deleting devDB pod %s: %v", p.Name, err)
+			}
 		}
 	}
+
 }
 
 // devURL returns the URL of the dev database for the given target URL.
@@ -69,10 +87,20 @@ func (r *AtlasSchemaReconciler) devURL(ctx context.Context, sc *dbv1alpha1.Atlas
 	}
 	// make sure we have a dev db running
 	key := nameDevDB(sc.ObjectMeta)
-	switch err := r.Get(ctx, key, &appsv1.Deployment{}); {
+	deploy := &appsv1.Deployment{}
+	switch err := r.Get(ctx, key, deploy); {
 	case err == nil:
 		// The dev database already exists,
-		// return the connection string.
+		// If it is scaled down, scale it up.
+		if deploy.Spec.Replicas == nil || *deploy.Spec.Replicas == 0 {
+			*deploy.Spec.Replicas = int32(1)
+			if err := r.Update(ctx, deploy); err != nil {
+				return "", transient(err)
+			}
+			r.recorder.Eventf(sc, corev1.EventTypeNormal, "ScaledUpDevDB", "Scaled up dev database deployment: %s", deploy.Name)
+			return "", transientAfter(errors.New("waiting for dev database to be ready"), 15*time.Second)
+		}
+
 	case apierrors.IsNotFound(err):
 		// The dev database does not exist, create it.
 		deploy, err := deploymentDevDB(key, drv, isSchemaBound(drv, &targetURL))

--- a/main.go
+++ b/main.go
@@ -54,8 +54,8 @@ const (
 	envNoUpdate = "SKIP_VERCHECK"
 	vercheckURL = "https://vercheck.ariga.io"
 	execPath    = "/atlas"
-	// disposeDevDB when enabled it deletes the devDB pods after the schema is created
-	disposeDevDB = "DISPOSE_DEVDB"
+	// prewarmDevDB when disabled it deletes the devDB pods after the schema is created
+	prewarmDevDB = "PREWARM_DEVDB"
 )
 
 func init() {
@@ -94,8 +94,8 @@ func main() {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
-	disposeDevDB := getDisposeDevDBEnv()
-	if err = controllers.NewAtlasSchemaReconciler(mgr, execPath, disposeDevDB).
+	prewarmDevDB := getPrewarmDevDBEnv()
+	if err = controllers.NewAtlasSchemaReconciler(mgr, execPath, prewarmDevDB).
 		SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AtlasSchema")
 		os.Exit(1)
@@ -159,16 +159,16 @@ func checkForUpdate() {
 	}
 }
 
-// getDisposeDevDBEnv returns the value of the env var DISPOSE_DEVDB.
-func getDisposeDevDBEnv() bool {
-	env := os.Getenv(disposeDevDB)
+// getPrewarmDevDBEnv returns the value of the env var PREWARM_DEVDB.
+func getPrewarmDevDBEnv() bool {
+	env := os.Getenv(prewarmDevDB)
 	if env == "" {
 		return false
 	}
-	disposeDevDB, err := strconv.ParseBool(env)
+	prewarmDevDB, err := strconv.ParseBool(env)
 	if err != nil {
-		setupLog.Error(err, "invalid value for env var DISPOSE_DEVDB, expected true or false")
+		setupLog.Error(err, "invalid value for env var PREWARM_DEVDB, expected true or false")
 		os.Exit(1)
 	}
-	return disposeDevDB
+	return prewarmDevDB
 }

--- a/main.go
+++ b/main.go
@@ -160,10 +160,11 @@ func checkForUpdate() {
 }
 
 // getPrewarmDevDBEnv returns the value of the env var PREWARM_DEVDB.
+// if the env var is not set, it returns true.
 func getPrewarmDevDBEnv() bool {
 	env := os.Getenv(prewarmDevDB)
 	if env == "" {
-		return false
+		return true
 	}
 	prewarmDevDB, err := strconv.ParseBool(env)
 	if err != nil {


### PR DESCRIPTION
Issues: https://github.com/ariga/atlas/issues/2051
Support flag `prewarmDevDB` to configure the lifecycle of the devdb. You can enable this configuration through `helm install` to keep the devdb running after the schema has been applied. By default, the flag will be set to `true`