### PR TITLE
charts: add aggregate cluster roles

### DIFF
--- a/charts/atlas-operator/templates/deployment.yaml
+++ b/charts/atlas-operator/templates/deployment.yaml
@@ -10,6 +10,9 @@ metadata:
   {{- include "atlas-operator.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- with .Values.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       control-plane: controller-manager
@@ -19,6 +22,9 @@ spec:
       labels:
         control-plane: controller-manager
       {{- include "atlas-operator.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
@@ -46,9 +52,9 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:
-          {{- toYaml .Values.resources | nindent 12 }}
+          {{- toYaml .Values.resources | nindent 10 }}
         securityContext:
-          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          {{- toYaml .Values.containerSecurityContext | nindent 10 }}
         env:
         - name: PREWARM_DEVDB
           value: "{{ .Values.prewarmDevDB }}"
@@ -70,6 +76,9 @@ spec:
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
       {{- end }}
       {{- with .Values.affinity }}
       affinity:

--- a/charts/atlas-operator/templates/rbac.yaml
+++ b/charts/atlas-operator/templates/rbac.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.rbac.aggregateClusterRoles }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "atlas-operator.fullname" . }}-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    {{- include "atlas-operator.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["db.atlasgo.io"]
+    resources: ["atlasmigration", "atlasschemas"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "atlas-operator.fullname" . }}-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    {{- include "atlas-operator.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["db.atlasgo.io"]
+    resources: ["atlasmigration", "atlasschemas"]
+    verbs: ["create", "delete", "patch", "update"]
+{{- end }}

--- a/charts/atlas-operator/values.yaml
+++ b/charts/atlas-operator/values.yaml
@@ -11,6 +11,7 @@ image:
 
 rbac:
   create: true
+  aggregateClusterRoles: false
 
 imagePullSecrets: []
 nameOverride: ""
@@ -22,6 +23,8 @@ serviceAccount:
   name: ""
 
 podAnnotations: {}
+
+podLabels: {}
 
 podSecurityContext:
   runAsNonRoot: true
@@ -36,6 +39,8 @@ securityContext:
 resources: {}
 
 nodeSelector: {}
+
+priorityClassName: ""
 
 tolerations: []
 


### PR DESCRIPTION
- adds option to aggregate cluster roles to user facing roles (disabled by default)
- adds options to set `revisionHistoryLimit`
- adds options to set `podLabels`
- fixes indentation for `resources` and `containerSecurityContext` key values