### PR TITLE
charts: support `labels` on pod/service account for Azure AD

### DIFF
--- a/charts/atlas-operator/templates/deployment.yaml
+++ b/charts/atlas-operator/templates/deployment.yaml
@@ -19,6 +19,9 @@ spec:
       labels:
         control-plane: controller-manager
       {{- include "atlas-operator.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
@@ -46,9 +49,9 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:
-          {{- toYaml .Values.resources | nindent 12 }}
+          {{- toYaml .Values.resources | nindent 10 }}
         securityContext:
-          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          {{- toYaml .Values.containerSecurityContext | nindent 10 }}
         env:
         - name: PREWARM_DEVDB
           value: "{{ .Values.prewarmDevDB }}"

--- a/charts/atlas-operator/templates/serviceaccount.yaml
+++ b/charts/atlas-operator/templates/serviceaccount.yaml
@@ -7,6 +7,9 @@ metadata:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: atlas-operator
     app.kubernetes.io/part-of: atlas-operator
+  {{- with .Values.serviceAccount.labels }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- include "atlas-operator.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:

--- a/charts/atlas-operator/values.yaml
+++ b/charts/atlas-operator/values.yaml
@@ -19,9 +19,12 @@ fullnameOverride: ""
 serviceAccount:
   create: true
   annotations: {}
+  labels: {}
   name: ""
 
 podAnnotations: {}
+
+podLabels: {}
 
 podSecurityContext:
   runAsNonRoot: true


### PR DESCRIPTION
This support azure-workload-identity, it requires a label on the pod and service-account.

https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview?tabs=go#pod-labels

```yaml
azure.workload.identity/use: "true"
```