### PR TITLE
atlas/schema: support `ALWAYS` for `policy.lint.review`

### DIFF
--- a/api/v1alpha1/atlasschema_types.go
+++ b/api/v1alpha1/atlasschema_types.go
@@ -167,6 +167,13 @@ type (
 	LintReview string
 )
 
+// LintReview values.
+const (
+	LintReviewAlways  LintReview = "ALWAYS"
+	LintReviewWarning LintReview = "WARNING"
+	LintReviewError   LintReview = "ERROR"
+)
+
 func init() {
 	SchemeBuilder.Register(&AtlasSchema{}, &AtlasSchemaList{})
 }

--- a/test/e2e/testscript/schema-review-always.txtar
+++ b/test/e2e/testscript/schema-review-always.txtar
@@ -1,0 +1,156 @@
+env DB_URL=postgres://root:pass@postgres.${NAMESPACE}:5432/postgres?sslmode=disable
+kubectl apply -f database.yaml
+kubectl create secret generic db-creds --from-literal=url=${DB_URL}
+# Wait for the DB ready before creating the schema
+kubectl-wait-ready -l app=postgres pods
+
+# Create the secret to store ATLAS_TOKEN
+kubectl create secret generic atlas-token --from-literal=ATLAS_TOKEN=${ATLAS_TOKEN}
+
+# Sync the $WORK directory to the controller pod
+kubectl cp -n ${CONTROLLER_NS} ${WORK} ${CONTROLLER}:/tmp/${NAMESPACE}/
+env DEV_URL=postgres://root:pass@postgres.${NAMESPACE}:5433/postgres?sslmode=disable
+# List all schema plans and remove them, it may come from previous failure runs
+atlas schema plan list --format="{{range .}}{{println .URL}}{{end}}" --dev-url=${DEV_URL} --repo=atlas://atlas-operator --from=file:///tmp/${NAMESPACE}/empty.hcl --to=file:///tmp/${NAMESPACE}/schema-v1.hcl
+plans-rm stdout
+
+# Create the schema
+kubectl apply -f schema.yaml
+# Ensure the controller is aware of the change
+kubectl wait --for=jsonpath='{.status.conditions[*].reason}'=ApprovalPending --timeout=120s AtlasSchemas/postgres
+
+# Get the plan URL from resource then approve it
+kubectl get AtlasSchemas/postgres -o go-template --template='{{ .status.planURL }}'
+envfile PLAN_URL=stdout
+atlas schema plan approve --url=${PLAN_URL}
+
+# The schema should be updated now
+kubectl-wait-ready AtlasSchema/postgres
+# Inspect the schema to ensure it's correct
+atlas schema inspect -u ${DB_URL}
+cmp stdout schema-v1.hcl
+-- empty.hcl --
+schema "public" {
+  comment = "standard public schema"
+}
+-- schema-v1.hcl --
+table "t1" {
+  schema = schema.public
+  column "id" {
+    null = false
+    type = integer
+  }
+  column "c1" {
+    null = true
+    type = integer
+  }
+  primary_key {
+    columns = [column.id]
+  }
+}
+schema "public" {
+  comment = "standard public schema"
+}
+-- schema.yaml --
+apiVersion: db.atlasgo.io/v1alpha1
+kind: AtlasSchema
+metadata:
+  name: postgres
+spec:
+  urlFrom:
+    secretKeyRef:
+      name: db-creds
+      key: url
+  policy:
+    lint:
+      review: ALWAYS
+  cloud:
+    repo: atlas-operator
+    tokenFrom:
+      secretKeyRef:
+        name: atlas-token
+        key: ATLAS_TOKEN
+  schema:
+    sql: |
+      create table t1 (
+        id int not null,
+        c1 int,
+        primary key (id)
+      );
+-- database.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  selector:
+    app: postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres
+    - name: postgres-dev
+      port: 5433
+      targetPort: postgres-dev
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+spec:
+  selector:
+    matchLabels:
+      app: postgres
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+      containers:
+        - name: postgres
+          image: postgres:15.4
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - all
+          env:
+            - name: POSTGRES_PASSWORD
+              value: pass
+            - name: POSTGRES_USER
+              value: root
+          ports:
+            - containerPort: 5432
+              name: postgres
+          startupProbe:
+            exec:
+              command: [ "pg_isready" ]
+            failureThreshold: 30
+            periodSeconds: 10
+        - name: postgres-dev
+          image: postgres:15.4
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - all
+          env:
+            - name: POSTGRES_PASSWORD
+              value: pass
+            - name: POSTGRES_USER
+              value: root
+            - name: PGPORT
+              value: "5433"
+          ports:
+            - containerPort: 5433
+              name: postgres-dev
+          startupProbe:
+            exec:
+              command: [ "pg_isready" ]
+            failureThreshold: 30
+            periodSeconds: 10


### PR DESCRIPTION
- The controller first checks existing plans, if no plans existing and the `lint.review` is set to `ALWAYS`, it creates new plan and reschedule the resource for the next reconcile loop.
