### PR TITLE
internal/controller: handle the case of Atlas returning multiple results

### DIFF
--- a/internal/controller/atlasschema_controller_test.go
+++ b/internal/controller/atlasschema_controller_test.go
@@ -672,7 +672,7 @@ func (t *test) initDB(statement string) {
 	require.NoError(t, err)
 	cli, err := atlasexec.NewClient(wd.Path(), "atlas")
 	require.NoError(t, err)
-	_, err = cli.SchemaApply(context.Background(), &atlasexec.SchemaApplyParams{
+	_, err = cli.SchemaApplySlice(context.Background(), &atlasexec.SchemaApplyParams{
 		URL:         t.dburl,
 		DevURL:      "sqlite://file2/?mode=memory",
 		To:          "file://./schema.sql",

--- a/internal/controller/common.go
+++ b/internal/controller/common.go
@@ -43,17 +43,16 @@ type (
 	}
 	// AtlasExec is the interface for the atlas exec client.
 	AtlasExec interface {
-		// MigrateApply runs the `migrate apply` command and returns the successful runs.
-		MigrateApply(context.Context, *atlasexec.MigrateApplyParams) (*atlasexec.MigrateApply, error)
+		// MigrateApplySlice runs the `migrate apply` command and returns the successful runs.
+		MigrateApplySlice(context.Context, *atlasexec.MigrateApplyParams) ([]*atlasexec.MigrateApply, error)
 		// MigrateDown runs the `migrate down` command.
 		MigrateDown(context.Context, *atlasexec.MigrateDownParams) (*atlasexec.MigrateDown, error)
 		// MigrateLint runs the `migrate lint` command.
 		MigrateLint(context.Context, *atlasexec.MigrateLintParams) (*atlasexec.SummaryReport, error)
 		// MigrateStatus runs the `migrate status` command.
 		MigrateStatus(context.Context, *atlasexec.MigrateStatusParams) (*atlasexec.MigrateStatus, error)
-
-		// SchemaApply runs the `schema apply` command.
-		SchemaApply(context.Context, *atlasexec.SchemaApplyParams) (*atlasexec.SchemaApply, error)
+		// SchemaApplySlice runs the `schema apply` command and returns the successful runs.
+		SchemaApplySlice(context.Context, *atlasexec.SchemaApplyParams) ([]*atlasexec.SchemaApply, error)
 		// SchemaInspect runs the `schema inspect` command.
 		SchemaInspect(ctx context.Context, params *atlasexec.SchemaInspectParams) (string, error)
 		// SchemaPush runs the `schema push` command.

--- a/internal/controller/lint.go
+++ b/internal/controller/lint.go
@@ -47,7 +47,7 @@ func (r *AtlasSchemaReconciler) lint(ctx context.Context, wd *atlasexec.WorkingD
 	if err != nil {
 		return err
 	}
-	plan, err := cli.SchemaApply(ctx, &atlasexec.SchemaApplyParams{
+	plans, err := cli.SchemaApplySlice(ctx, &atlasexec.SchemaApplyParams{
 		Env:    data.EnvName,
 		Vars:   vars,
 		To:     data.Desired.String(),
@@ -63,9 +63,12 @@ func (r *AtlasSchemaReconciler) lint(ctx context.Context, wd *atlasexec.WorkingD
 				"unable to remove temporary directory", "dir", dir)
 		}
 	}()
+	if len(plans) != 1 {
+		return fmt.Errorf("unexpected number of schema plans: %d", len(plans))
+	}
 	dir, err := memDir(map[string]string{
 		"1.sql": current,
-		"2.sql": strings.Join(plan.Changes.Pending, ";\n"),
+		"2.sql": strings.Join(plans[0].Changes.Pending, ";\n"),
 	})
 	if err != nil {
 		return err

--- a/internal/controller/testhelper.go
+++ b/internal/controller/testhelper.go
@@ -82,9 +82,9 @@ func (m *mockAtlasExec) WhoAmI(context.Context) (*atlasexec.WhoAmI, error) {
 	return m.whoami.res, m.whoami.err
 }
 
-// SchemaApply implements AtlasExec.
-func (m *mockAtlasExec) SchemaApply(ctx context.Context, params *atlasexec.SchemaApplyParams) (*atlasexec.SchemaApply, error) {
-	return m.schemaApply.res, m.schemaApply.err
+// SchemaAppleSlice implements AtlasExec.
+func (m *mockAtlasExec) SchemaApplySlice(ctx context.Context, params *atlasexec.SchemaApplyParams) ([]*atlasexec.SchemaApply, error) {
+	return []*atlasexec.SchemaApply{m.schemaApply.res}, m.schemaApply.err
 }
 
 // SchemaInspect implements AtlasExec.
@@ -95,6 +95,11 @@ func (m *mockAtlasExec) SchemaInspect(ctx context.Context, params *atlasexec.Sch
 // MigrateApply implements AtlasExec.
 func (m *mockAtlasExec) MigrateApply(context.Context, *atlasexec.MigrateApplyParams) (*atlasexec.MigrateApply, error) {
 	return m.apply.res, m.apply.err
+}
+
+// MigrateApplySlice implements AtlasExec.
+func (m *mockAtlasExec) MigrateApplySlice(context.Context, *atlasexec.MigrateApplyParams) ([]*atlasexec.MigrateApply, error) {
+	return []*atlasexec.MigrateApply{m.apply.res}, m.apply.err
 }
 
 // MigrateDown implements AtlasExec.


### PR DESCRIPTION
This PR is needed to set up the case of `multi-tenancy` when results are returned in batch. There are no breaking changes here, it only replaces the SDK function.