### PR TITLE
internal/controller: generate hash of declarative flow by using "schema inspect"

### DIFF
--- a/internal/controller/atlasschema_controller_test.go
+++ b/internal/controller/atlasschema_controller_test.go
@@ -77,7 +77,7 @@ func TestReconcile_ReadyButDiff(t *testing.T) {
 		Spec: dbv1alpha1.AtlasSchemaSpec{
 			Schema: dbv1alpha1.Schema{SQL: "create table foo (id int primary key);"},
 			TargetSpec: dbv1alpha1.TargetSpec{
-				URL: "mysql://root:password@localhost:3306/test",
+				URL: "sqlite://file?mode=memory",
 			},
 		},
 		Status: dbv1alpha1.AtlasSchemaStatus{
@@ -442,7 +442,7 @@ func TestBadSQL(t *testing.T) {
 	cont := tt.cond()
 	require.EqualValues(t, schemaReadyCond, cont.Type)
 	require.EqualValues(t, metav1.ConditionFalse, cont.Status)
-	require.EqualValues(t, "LintPolicyError", cont.Reason)
+	require.EqualValues(t, "CalculatingHash", cont.Reason)
 	require.Contains(t, cont.Message, "executing statement:")
 }
 
@@ -500,6 +500,9 @@ func TestConfigTemplate(t *testing.T) {
 	err := data.render(&buf)
 	require.NoError(t, err)
 	expected := `env "kubernetes" {
+  schema {
+    src = "file://schema.sql"
+  }
   url     = "mysql://root:password@localhost:3306/test"
   dev     = "mysql://root:password@localhost:3306/dev"
   schemas = ["foo", "bar"]
@@ -573,6 +576,9 @@ env "kubernetes" {
   dev     = "mysql://root:password@localhost:3306/dev"
   schemas = ["foo", "bar"]
   url     = "mysql://root:password@localhost:3306/test"
+  schema {
+    src = "file://schema.sql"
+  }
 }
   `
 	require.EqualValues(t, expected, buf.String())
@@ -599,6 +605,9 @@ env {
   dev     = "mysql://root:password@localhost:3306/dev"
   schemas = ["foo", "bar"]
   url     = "mysql://root:password@localhost:3306/test"
+  schema {
+    src = "file://schema.sql"
+  }
 }`
 	require.EqualValues(t, expected, buf.String())
 }

--- a/internal/controller/common.go
+++ b/internal/controller/common.go
@@ -152,6 +152,15 @@ func isChecksumErr(err error) bool {
 	return strings.Contains(err.Error(), "checksum mismatch")
 }
 
+// isConnectionErr returns true if the error is a connection error.
+func isConnectionErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "connection timed out") ||
+		strings.Contains(err.Error(), "connection refused")
+}
+
 // transientError is an error that should be retried.
 type transientError struct {
 	err   error

--- a/test/e2e/testscript/schema-hash-configmap.txtar
+++ b/test/e2e/testscript/schema-hash-configmap.txtar
@@ -7,66 +7,48 @@ kubectl-wait-available deploy/mysql
 # Wait for the DB ready before creating the schema
 kubectl-wait-ready -l app=mysql pods
 
+# Create the configmap to store the schema.sql
+kubectl create configmap mysql-schema --from-file=./schema-v1 --dry-run=client -o yaml
+stdin stdout
+kubectl apply -f -
+
 # Create the schema
 kubectl apply -f schema.yaml
 kubectl-wait-ready AtlasSchema/mysql
+
 kubectl get -o jsonpath --template='{.status.observed_hash}' AtlasSchema/mysql
 stdout oAoRLC2AXyGha6pKDollSqBB5ovjB\+qK78aAN9dkOow\=
-# Inspect the schema to ensure it's correct
-atlas schema inspect -u ${DB_URL}
-cmp stdout schema.hcl
 
-kubectl patch -f schema.yaml --type merge --patch-file patch-remove-bio.yaml
-exec sleep 10
+# Update the configmap with the new schema
+kubectl create configmap mysql-schema --from-file=./schema-v2 --dry-run=client -o yaml
+stdin stdout
+kubectl apply -f -
+
+# Ensure the controller is aware of the change
+kubectl wait --for=condition=ready=false --timeout=500s AtlasSchema/mysql
 kubectl-wait-ready AtlasSchema/mysql
-# Ensure the schema is updated
+
+# Hash should be updated
 kubectl get -o jsonpath --template='{.status.observed_hash}' AtlasSchema/mysql
-stdout UmrKZN7GNsjWxLOq6VJ3vejqnvBQU9BeoDZlL\/2LTKU\=
-# Inspect the schema again to ensure it still has the bio column
-atlas schema inspect -u ${DB_URL}
-cmp stdout schema.hcl
--- schema.hcl --
-table "users" {
-  schema = schema.myapp
-  column "id" {
-    null           = false
-    type           = int
-    auto_increment = true
-  }
-  column "name" {
-    null = false
-    type = varchar(255)
-  }
-  column "email" {
-    null = false
-    type = varchar(255)
-  }
-  column "short_bio" {
-    null = false
-    type = varchar(255)
-  }
-  primary_key {
-    columns = [column.id]
-  }
-  index "email" {
-    unique  = true
-    columns = [column.email]
-  }
-}
-schema "myapp" {
-  charset = "utf8mb4"
-  collate = "utf8mb4_0900_ai_ci"
-}
--- patch-remove-bio.yaml --
-spec:
-  schema:
-    sql: |
-      create table users (
-        id int not null auto_increment,
-        name varchar(255) not null,
-        email varchar(255) unique not null,
-        primary key (id)
-      );
+stdout mlBKa2H4Mt7J8uStzuFj6Ps0XRIB9z3EuZPfOw6BeIA\=
+
+-- schema-v1/schema.sql --
+create table users (
+  id int not null auto_increment,
+  name varchar(255) not null,
+  email varchar(255) unique not null,
+  short_bio varchar(255) not null,
+  primary key (id)
+);
+-- schema-v2/schema.sql --
+create table users (
+  id int not null auto_increment,
+  name varchar(255) not null,
+  email varchar(255) unique not null,
+  short_bio varchar(255) not null,
+  phone varchar(255) not null,
+  primary key (id)
+);
 -- schema.yaml --
 apiVersion: db.atlasgo.io/v1alpha1
 kind: AtlasSchema
@@ -77,19 +59,10 @@ spec:
     secretKeyRef:
       name: db-creds
       key: url
-  policy:
-    diff:
-      skip:
-        drop_column: true
   schema:
-    sql: |
-      create table users (
-        id int not null auto_increment,
-        name varchar(255) not null,
-        email varchar(255) unique not null,
-        short_bio varchar(255) not null,
-        primary key (id)
-      );
+    configMapKeyRef:
+      key: schema.sql
+      name: mysql-schema
 -- database.yaml --
 apiVersion: v1
 kind: Service
@@ -102,6 +75,9 @@ spec:
     - name: mysql
       port: 3306
       targetPort: mysql
+    - name: mysql-dev
+      port: 3307
+      targetPort: mysql-dev
   type: ClusterIP
 ---
 apiVersion: apps/v1
@@ -129,6 +105,23 @@ spec:
           ports:
             - containerPort: 3306
               name: mysql
+          startupProbe:
+            exec:
+              command: [ "mysql", "-ppass", "-h", "127.0.0.1", "-e", "SELECT 1" ]
+            failureThreshold: 30
+            periodSeconds: 10
+        - name: mysql-dev
+          image: mysql:latest
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: pass
+            - name: MYSQL_DATABASE
+              value: myapp
+            - name: MYSQL_TCP_PORT
+              value: "3307"
+          ports:
+            - containerPort: 3307
+              name: mysql-dev
           startupProbe:
             exec:
               command: [ "mysql", "-ppass", "-h", "127.0.0.1", "-e", "SELECT 1" ]

--- a/test/e2e/testscript/schema-hash.txtar
+++ b/test/e2e/testscript/schema-hash.txtar
@@ -10,63 +10,38 @@ kubectl-wait-ready -l app=mysql pods
 # Create the schema
 kubectl apply -f schema.yaml
 kubectl-wait-ready AtlasSchema/mysql
+
 kubectl get -o jsonpath --template='{.status.observed_hash}' AtlasSchema/mysql
 stdout oAoRLC2AXyGha6pKDollSqBB5ovjB\+qK78aAN9dkOow\=
-# Inspect the schema to ensure it's correct
-atlas schema inspect -u ${DB_URL}
-cmp stdout schema.hcl
 
-kubectl patch -f schema.yaml --type merge --patch-file patch-remove-bio.yaml
-exec sleep 10
+# Update the configmap with the new schema
+kubectl patch -f schema.yaml --type merge --patch-file schema-v2-patch.yaml
+
+# Ensure the controller is aware of the change
+kubectl wait --for=condition=ready=false --timeout=500s AtlasSchema/mysql
 kubectl-wait-ready AtlasSchema/mysql
-# Ensure the schema is updated
+
+# Hash should be updated
 kubectl get -o jsonpath --template='{.status.observed_hash}' AtlasSchema/mysql
-stdout UmrKZN7GNsjWxLOq6VJ3vejqnvBQU9BeoDZlL\/2LTKU\=
-# Inspect the schema again to ensure it still has the bio column
-atlas schema inspect -u ${DB_URL}
-cmp stdout schema.hcl
--- schema.hcl --
-table "users" {
-  schema = schema.myapp
-  column "id" {
-    null           = false
-    type           = int
-    auto_increment = true
-  }
-  column "name" {
-    null = false
-    type = varchar(255)
-  }
-  column "email" {
-    null = false
-    type = varchar(255)
-  }
-  column "short_bio" {
-    null = false
-    type = varchar(255)
-  }
-  primary_key {
-    columns = [column.id]
-  }
-  index "email" {
-    unique  = true
-    columns = [column.email]
-  }
-}
-schema "myapp" {
-  charset = "utf8mb4"
-  collate = "utf8mb4_0900_ai_ci"
-}
--- patch-remove-bio.yaml --
-spec:
-  schema:
-    sql: |
-      create table users (
-        id int not null auto_increment,
-        name varchar(255) not null,
-        email varchar(255) unique not null,
-        primary key (id)
-      );
+stdout mlBKa2H4Mt7J8uStzuFj6Ps0XRIB9z3EuZPfOw6BeIA\=
+
+-- schema-v1/schema.sql --
+create table users (
+  id int not null auto_increment,
+  name varchar(255) not null,
+  email varchar(255) unique not null,
+  short_bio varchar(255) not null,
+  primary key (id)
+);
+-- schema-v2/schema.sql --
+create table users (
+  id int not null auto_increment,
+  name varchar(255) not null,
+  email varchar(255) unique not null,
+  short_bio varchar(255) not null,
+  phone varchar(255) not null,
+  primary key (id)
+);
 -- schema.yaml --
 apiVersion: db.atlasgo.io/v1alpha1
 kind: AtlasSchema
@@ -77,10 +52,6 @@ spec:
     secretKeyRef:
       name: db-creds
       key: url
-  policy:
-    diff:
-      skip:
-        drop_column: true
   schema:
     sql: |
       create table users (
@@ -88,6 +59,18 @@ spec:
         name varchar(255) not null,
         email varchar(255) unique not null,
         short_bio varchar(255) not null,
+        primary key (id)
+      );
+-- schema-v2-patch.yaml --
+spec:
+  schema:
+    sql: |
+      create table users (
+        id int not null auto_increment,
+        name varchar(255) not null,
+        email varchar(255) unique not null,
+        short_bio varchar(255) not null,
+        phone varchar(255) not null,
         primary key (id)
       );
 -- database.yaml --
@@ -102,6 +85,9 @@ spec:
     - name: mysql
       port: 3306
       targetPort: mysql
+    - name: mysql-dev
+      port: 3307
+      targetPort: mysql-dev
   type: ClusterIP
 ---
 apiVersion: apps/v1
@@ -129,6 +115,23 @@ spec:
           ports:
             - containerPort: 3306
               name: mysql
+          startupProbe:
+            exec:
+              command: [ "mysql", "-ppass", "-h", "127.0.0.1", "-e", "SELECT 1" ]
+            failureThreshold: 30
+            periodSeconds: 10
+        - name: mysql-dev
+          image: mysql:latest
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: pass
+            - name: MYSQL_DATABASE
+              value: myapp
+            - name: MYSQL_TCP_PORT
+              value: "3307"
+          ports:
+            - containerPort: 3307
+              name: mysql-dev
           startupProbe:
             exec:
               command: [ "mysql", "-ppass", "-h", "127.0.0.1", "-e", "SELECT 1" ]

--- a/test/e2e/testscript/schema-review-always.txtar
+++ b/test/e2e/testscript/schema-review-always.txtar
@@ -33,7 +33,7 @@ kubectl-wait-ready AtlasSchema/postgres
 atlas schema inspect -u ${DB_URL}
 cmp stdout schema-v1.hcl
 kubectl get -o jsonpath --template='{.status.observed_hash}' AtlasSchema/postgres
-stdout 2a59599f3d4f2f07d4fabb87bf872030020fd7410e10a1042ace7a0865953cac
+stdout lhl512tzvwQXJ9lroGuRNzGS6fiic8r9ohGMV\+\/Ij0w\=
 
 # Apply again without any change in the schema, it should be a no-op
 kubectl patch -f schema.yaml --type merge --patch-file patch-comment.yaml
@@ -44,7 +44,7 @@ kubectl-wait-ready AtlasSchema/postgres
 atlas schema inspect -u ${DB_URL}
 cmp stdout schema-v1.hcl
 kubectl get -o jsonpath --template='{.status.observed_hash}' AtlasSchema/postgres
-stdout 6a60e051a482fb40392f768e0a080bc101bd9d87efa21ff40472b1dbd7d4e7a8
+stdout lhl512tzvwQXJ9lroGuRNzGS6fiic8r9ohGMV\+\/Ij0w\=
 -- empty.hcl --
 schema "public" {
   comment = "standard public schema"


### PR DESCRIPTION
This PR replaces the hashing mechanism by using `schema inspect`. This change ensures that the Operator correctly detects changes in the remote schema.