### PR TITLE
internal/controller: track reconciliation failure count

### DIFF
--- a/api/v1alpha1/atlasmigration_types.go
+++ b/api/v1alpha1/atlasmigration_types.go
@@ -58,6 +58,8 @@ type (
 		ObservedHash string `json:"observed_hash"`
 		// LastApplied is the unix timestamp of the most recent successful versioned migration.
 		LastApplied int64 `json:"lastApplied"`
+		// Failed is the number of times the migration has failed.
+		Failed int `json:"failed"`
 	}
 	// AtlasMigrationSpec defines the desired state of AtlasMigration
 	AtlasMigrationSpec struct {
@@ -157,6 +159,7 @@ func (m *AtlasMigration) IsHashModified(hash string) bool {
 
 // SetReady sets the ready condition to true.
 func (m *AtlasMigration) SetReady(status AtlasMigrationStatus) {
+	status.Failed = 0
 	m.Status = status
 	meta.SetStatusCondition(&m.Status.Conditions, metav1.Condition{
 		Type:   readyCond,
@@ -167,6 +170,7 @@ func (m *AtlasMigration) SetReady(status AtlasMigrationStatus) {
 
 // SetNotReady sets the ready condition to false.
 func (m *AtlasMigration) SetNotReady(reason, message string) {
+	m.Status.Failed++
 	meta.SetStatusCondition(&m.Status.Conditions, metav1.Condition{
 		Type:    readyCond,
 		Status:  metav1.ConditionFalse,

--- a/api/v1alpha1/atlasschema_types.go
+++ b/api/v1alpha1/atlasschema_types.go
@@ -68,6 +68,8 @@ type (
 		// PlanLink is the link to the schema plan on the Atlas Cloud.
 		// +optional
 		PlanLink string `json:"planLink"`
+		// Failed is the number of times the schema has failed to apply.
+		Failed int `json:"failed"`
 	}
 	// AtlasSchemaSpec defines the desired state of AtlasSchema
 	AtlasSchemaSpec struct {
@@ -211,6 +213,7 @@ func (sc *AtlasSchema) SetReady(status AtlasSchemaStatus, report any) {
 	} else {
 		msg = "The schema has been applied successfully."
 	}
+	status.Failed = 0
 	sc.Status = status
 	meta.SetStatusCondition(&sc.Status.Conditions, metav1.Condition{
 		Type:    readyCond,
@@ -223,6 +226,7 @@ func (sc *AtlasSchema) SetReady(status AtlasSchemaStatus, report any) {
 // SetNotReady sets the Ready condition to false
 // with the given reason and message.
 func (sc *AtlasSchema) SetNotReady(reason, msg string) {
+	sc.Status.Failed++
 	meta.SetStatusCondition(&sc.Status.Conditions, metav1.Condition{
 		Type:    readyCond,
 		Status:  metav1.ConditionFalse,

--- a/charts/atlas-operator/templates/crds/crd.yaml
+++ b/charts/atlas-operator/templates/crds/crd.yaml
@@ -498,6 +498,9 @@ spec:
                   - type
                   type: object
                 type: array
+              failed:
+                description: Failed is the number of times the migration has failed.
+                type: integer
               lastApplied:
                 description: LastApplied is the unix timestamp of the most recent
                   successful versioned migration.
@@ -516,6 +519,7 @@ spec:
                   versioned migration.
                 type: string
             required:
+            - failed
             - lastApplied
             - observed_hash
             type: object
@@ -1079,6 +1083,10 @@ spec:
                   - type
                   type: object
                 type: array
+              failed:
+                description: Failed is the number of times the schema has failed to
+                  apply.
+                type: integer
               last_applied:
                 description: LastApplied is the unix timestamp of the most recent
                   successful schema apply operation.
@@ -1096,6 +1104,7 @@ spec:
                 description: PlanURL is the URL of the schema plan to apply.
                 type: string
             required:
+            - failed
             - last_applied
             - observed_hash
             type: object

--- a/config/crd/bases/db.atlasgo.io_atlasmigrations.yaml
+++ b/config/crd/bases/db.atlasgo.io_atlasmigrations.yaml
@@ -512,6 +512,9 @@ spec:
                   - type
                   type: object
                 type: array
+              failed:
+                description: Failed is the number of times the migration has failed.
+                type: integer
               lastApplied:
                 description: LastApplied is the unix timestamp of the most recent
                   successful versioned migration.
@@ -530,6 +533,7 @@ spec:
                   versioned migration.
                 type: string
             required:
+            - failed
             - lastApplied
             - observed_hash
             type: object

--- a/config/crd/bases/db.atlasgo.io_atlasschemas.yaml
+++ b/config/crd/bases/db.atlasgo.io_atlasschemas.yaml
@@ -566,6 +566,10 @@ spec:
                   - type
                   type: object
                 type: array
+              failed:
+                description: Failed is the number of times the schema has failed to
+                  apply.
+                type: integer
               last_applied:
                 description: LastApplied is the unix timestamp of the most recent
                   successful schema apply operation.
@@ -583,6 +587,7 @@ spec:
                 description: PlanURL is the URL of the schema plan to apply.
                 type: string
             required:
+            - failed
             - last_applied
             - observed_hash
             type: object


### PR DESCRIPTION
This pull request introduces a new field (`failed`) to track the number of failed when the operator encounters an error. The recorded value will be used to calculate backoff time in the next PR