### PR TITLE
internal/controller: add exponential backoff

### DIFF
--- a/api/v1alpha1/reason.go
+++ b/api/v1alpha1/reason.go
@@ -30,3 +30,13 @@ const (
 	// ReasonCreatingWorkingDir represents the reason for creating a working directory.
 	ReasonCreatingWorkingDir = "CreatingWorkingDir"
 )
+
+// isFailedReason returns true if the given reason is a failed reason.
+func isFailedReason(reason string) bool {
+	switch reason {
+	case ReasonReconciling, ReasonGettingDevDB, ReasonApprovalPending:
+		return false
+	default:
+		return true
+	}
+}

--- a/charts/atlas-operator/templates/crds/crd.yaml
+++ b/charts/atlas-operator/templates/crds/crd.yaml
@@ -45,6 +45,10 @@ spec:
           spec:
             description: AtlasMigrationSpec defines the desired state of AtlasMigration
             properties:
+              backoffLimit:
+                default: 20
+                description: BackoffLimit is the number of retries on error.
+                type: integer
               baseline:
                 description: BaselineVersion defines the baseline version of the database
                   on the first migration.
@@ -577,6 +581,10 @@ spec:
           spec:
             description: AtlasSchemaSpec defines the desired state of AtlasSchema
             properties:
+              backoffLimit:
+                default: 20
+                description: BackoffLimit is the number of retries on error.
+                type: integer
               cloud:
                 description: Cloud defines the Atlas Cloud configuration.
                 properties:

--- a/config/crd/bases/db.atlasgo.io_atlasmigrations.yaml
+++ b/config/crd/bases/db.atlasgo.io_atlasmigrations.yaml
@@ -59,6 +59,10 @@ spec:
           spec:
             description: AtlasMigrationSpec defines the desired state of AtlasMigration
             properties:
+              backoffLimit:
+                default: 20
+                description: BackoffLimit is the number of retries on error.
+                type: integer
               baseline:
                 description: BaselineVersion defines the baseline version of the database
                   on the first migration.

--- a/config/crd/bases/db.atlasgo.io_atlasschemas.yaml
+++ b/config/crd/bases/db.atlasgo.io_atlasschemas.yaml
@@ -59,6 +59,10 @@ spec:
           spec:
             description: AtlasSchemaSpec defines the desired state of AtlasSchema
             properties:
+              backoffLimit:
+                default: 20
+                description: BackoffLimit is the number of retries on error.
+                type: integer
               cloud:
                 description: Cloud defines the Atlas Cloud configuration.
                 properties:

--- a/internal/controller/common_test.go
+++ b/internal/controller/common_test.go
@@ -15,7 +15,9 @@
 package controller
 
 import (
+	"reflect"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -130,6 +132,53 @@ env {
 			mergeBlocks(dst.Body(), src.Body())
 			if got := string(dst.Bytes()); got != tt.expected {
 				t.Errorf("mergeBlocks() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func Test_backoffDelayAt(t *testing.T) {
+	type args struct {
+		retry int
+	}
+	tests := []struct {
+		name string
+		args args
+		want time.Duration
+	}{
+		{
+			name: "0",
+			args: args{
+				retry: 0,
+			},
+			want: 0,
+		},
+		{
+			name: "1",
+			args: args{
+				retry: 1,
+			},
+			want: 5 * time.Second,
+		},
+		{
+			name: "2",
+			args: args{
+				retry: 2,
+			},
+			want: 10 * time.Second,
+		},
+		{
+			name: "20",
+			args: args{
+				retry: 20,
+			},
+			want: 100 * time.Second,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := backoffDelayAt(tt.args.retry); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("backoffDelayAt() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/controller/devdb.go
+++ b/internal/controller/devdb.go
@@ -21,7 +21,6 @@ import (
 	"net/url"
 	"os"
 	"slices"
-	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -59,7 +58,7 @@ type (
 	}
 )
 
-var errWaitDevDB = transientAfter(errors.New("waiting for dev database to be ready"), 15*time.Second)
+var errWaitDevDB = transient(errors.New("waiting for dev database to be ready"))
 
 func newDevDB(mgr Manager, r record.EventRecorder, prewarm bool) *devDBReconciler {
 	if r == nil {

--- a/test/e2e/testscript/migration-backoff-limit.txtar
+++ b/test/e2e/testscript/migration-backoff-limit.txtar
@@ -1,0 +1,111 @@
+env DB_URL=mysql://root:pass@mysql.${NAMESPACE}:3306/myapp
+kubectl apply -f database.yaml
+kubectl create secret generic db-creds --from-literal=url=${DB_URL}
+
+# Wait for the first pod created
+kubectl-wait-available deploy/mysql
+# Wait for the DB ready before creating the schema
+kubectl-wait-ready -l app=mysql pods
+kubectl apply -f migration.yaml
+
+# Wait for the controller to detect the change
+exec sleep 20
+
+kubectl get -o jsonpath --template='{.status.failed}' AtlasMigration/mysql
+stdout 3
+
+# Create configmap to store the migrations directory
+kubectl create configmap migration-dir --from-file=migrations-v1
+kubectl patch -f migration.yaml --type merge --patch-file patch-target.yaml
+
+# Wait for the controller to detect the change
+exec sleep 10
+
+kubectl-wait-ready AtlasMigration/mysql
+kubectl get -o jsonpath --template='{.status.failed}' AtlasMigration/mysql
+stdout 0
+
+-- migrations-v1/atlas.sum --
+h1:XBXbh+rzLis8gknjlIqnxXLBkOZ+sN2v2p7KjyVFYYM=
+20230316085611.sql h1:br6W6LPEnnsejlz/7hRm9zthwStCzjN2vZkqVPxlmvo=
+20230316090502.sql h1:GfeRjkSeoCt3JVRtLQNa/r50lRfpAPXS7AqTU2ZNFgY=
+-- migrations-v1/20230316085611.sql --
+-- Create "users" table
+CREATE TABLE `users` (
+  `id` int NOT NULL,
+  `user_name` varchar(255) NOT NULL,
+  `email` varchar(255) NOT NULL,
+  PRIMARY KEY (`id`)
+) CHARSET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+-- migrations-v1/20230316090502.sql --
+-- Create "posts" table
+CREATE TABLE `posts` (
+  `id` int NOT NULL,
+  `user_id` int NOT NULL,
+  `title` varchar(255) NOT NULL,
+  `body` text NOT NULL,
+  PRIMARY KEY (`id`),
+  INDEX `user_id` (`user_id`),
+  CONSTRAINT `posts_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+) CHARSET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+-- migration.yaml --
+apiVersion: db.atlasgo.io/v1alpha1
+kind: AtlasMigration
+metadata:
+  name: mysql
+spec:
+  backoffLimit: 2
+  dir:
+    configMapRef:
+      name: "migration-dir"
+-- patch-target.yaml --
+spec:
+  backoffLimit: 20
+  urlFrom:
+    secretKeyRef:
+      name: db-creds
+      key: url
+-- database.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+spec:
+  selector:
+    app: mysql
+  ports:
+    - name: mysql
+      port: 3306
+      targetPort: mysql
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql
+spec:
+  selector:
+    matchLabels:
+      app: mysql
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      containers:
+        - name: mysql
+          image: mysql:latest
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: pass
+            - name: MYSQL_DATABASE
+              value: myapp
+          ports:
+            - containerPort: 3306
+              name: mysql
+          startupProbe:
+            exec:
+              command: [ "mysql", "-ppass", "-h", "127.0.0.1", "-e", "SELECT 1" ]
+            failureThreshold: 30
+            periodSeconds: 10

--- a/test/e2e/testscript/schema-backoff-limit.txtar
+++ b/test/e2e/testscript/schema-backoff-limit.txtar
@@ -1,0 +1,94 @@
+env DB_URL=mysql://root:pass@mysql.${NAMESPACE}:3306/myapp
+kubectl apply -f database.yaml
+kubectl create secret generic db-creds --from-literal=url=${DB_URL}
+
+# Wait for the first pod created
+kubectl-wait-available deploy/mysql
+# Wait for the DB ready before creating the schema
+kubectl-wait-ready -l app=mysql pods
+
+# Create the schema
+kubectl apply -f schema.yaml
+
+# Wait for the controller to detect the change
+exec sleep 20
+
+kubectl get -o jsonpath --template='{.status.failed}' AtlasSchema/mysql
+stdout 3
+
+kubectl patch -f schema.yaml --type merge --patch-file patch-target.yaml
+
+# Wait for the controller to detect the change
+exec sleep 10
+
+kubectl-wait-ready AtlasSchema/mysql
+kubectl get -o jsonpath --template='{.status.failed}' AtlasSchema/mysql
+stdout 0
+
+-- schema.yaml --
+apiVersion: db.atlasgo.io/v1alpha1
+kind: AtlasSchema
+metadata:
+  name: mysql
+spec:
+  backoffLimit: 5
+  schema:
+    sql: |
+      create table users (
+        id int not null auto_increment,
+        name varchar(255) not null,
+        email varchar(255) unique not null,
+        short_bio varchar(255) not null,
+        primary key (id)
+      );
+-- patch-target.yaml --
+spec:
+  backoffLimit: 2
+  urlFrom:
+    secretKeyRef:
+      name: db-creds
+      key: url
+-- database.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+spec:
+  selector:
+    app: mysql
+  ports:
+    - name: mysql
+      port: 3306
+      targetPort: mysql
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql
+spec:
+  selector:
+    matchLabels:
+      app: mysql
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      containers:
+        - name: mysql
+          image: mysql:latest
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: pass
+            - name: MYSQL_DATABASE
+              value: myapp
+          ports:
+            - containerPort: 3306
+              name: mysql
+          startupProbe:
+            exec:
+              command: [ "mysql", "-ppass", "-h", "127.0.0.1", "-e", "SELECT 1" ]
+            failureThreshold: 30
+            periodSeconds: 10


### PR DESCRIPTION
This PR replaces the retry mechanism for errors from a fixed 5-second interval to an exponential backoff strategy. The delay is now calculated base on the number of failures for each resource.

A `backoffLimit` field has been added to the spec to configure the maximum number of retries. By default, it is set to 20. If backoffLimit is set to 0, retries will be unlimited.

When the number of retries exceeds the `backoffLimit`, the controller will log an event to notify about this.
![Screenshot 2025-02-13 at 20 53 45](https://github.com/user-attachments/assets/e8ad2e32-7ad9-415a-ab78-74bc26eae32e)

Example of setting `backoffLimit` for `AtlasMigration` and `Atlas Schema` resources:
```
apiVersion: db.atlasgo.io/v1alpha1
kind: AtlasMigration
metadata:
  name: mysql
spec:
  backoffLimit: 5
  dir:
    configMapRef:
      name: "migration-dir"
---
apiVersion: db.atlasgo.io/v1alpha1
kind: AtlasSchema
metadata:
  name: mysql
spec:
  backoffLimit: 5
  schema:
    sql: |
      create table users (
        id int not null auto_increment,
        name varchar(255) not null,
        email varchar(255) unique not null,
        short_bio varchar(255) not null,
        primary key (id)
      );
```