### PR TITLE
internal/controller: replace string literals with constants for reasons

### DIFF
--- a/api/v1alpha1/atlasmigration_types.go
+++ b/api/v1alpha1/atlasmigration_types.go
@@ -164,7 +164,7 @@ func (m *AtlasMigration) SetReady(status AtlasMigrationStatus) {
 	meta.SetStatusCondition(&m.Status.Conditions, metav1.Condition{
 		Type:   readyCond,
 		Status: metav1.ConditionTrue,
-		Reason: "Applied",
+		Reason: ReasonApplied,
 	})
 }
 

--- a/api/v1alpha1/atlasschema_types.go
+++ b/api/v1alpha1/atlasschema_types.go
@@ -218,7 +218,7 @@ func (sc *AtlasSchema) SetReady(status AtlasSchemaStatus, report any) {
 	meta.SetStatusCondition(&sc.Status.Conditions, metav1.Condition{
 		Type:    readyCond,
 		Status:  metav1.ConditionTrue,
-		Reason:  "Applied",
+		Reason:  ReasonApplied,
 		Message: msg,
 	})
 }

--- a/api/v1alpha1/reason.go
+++ b/api/v1alpha1/reason.go
@@ -1,0 +1,32 @@
+// Copyright 2025 The Atlas Operator Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+const (
+	// ReasonReconciling represents for the reconciliation is in progress.
+	ReasonReconciling = "Reconciling"
+	// ReasonGettingDevDB represents the reason for getting the dev database.
+	ReasonGettingDevDB = "GettingDevDB"
+	// ReasonWhoAmI represents the reason for getting the current user via Atlas CLI
+	ReasonWhoAmI = "WhoAmI"
+	// ReasonApplyingMigration represents the reason for applied a schema/migration resource successfully.
+	ReasonApplied = "Applied"
+	// ReasonApprovalPending represents the reason for the approval is pending.
+	ReasonApprovalPending = "ApprovalPending"
+	// ReasonCreatingAtlasClient represents the reason for creating an Atlas client.
+	ReasonCreatingAtlasClient = "CreatingAtlasClient"
+	// ReasonCreatingWorkingDir represents the reason for creating a working directory.
+	ReasonCreatingWorkingDir = "CreatingWorkingDir"
+)

--- a/internal/controller/atlasschema_controller_test.go
+++ b/internal/controller/atlasschema_controller_test.go
@@ -134,7 +134,7 @@ func TestReconcile_Reconcile(t *testing.T) {
 		},
 	})
 	// Third reconcile, return error for missing schema
-	assert(ctrl.Result{}, false, "CreatingWorkingDir", "the desired state is not set")
+	assert(ctrl.Result{}, false, dbv1alpha1.ReasonCreatingWorkingDir, "the desired state is not set")
 	// Add schema,
 	h.patch(t, &dbv1alpha1.AtlasSchema{
 		ObjectMeta: meta,


### PR DESCRIPTION
This PR groups some reasons that are used in both versioned and declarative flows via constants.