### PR TITLE
Fix issue where long schemas won't apply

### DIFF
--- a/api/v1alpha1/atlasschema_types.go
+++ b/api/v1alpha1/atlasschema_types.go
@@ -181,7 +181,16 @@ const (
 	LintReviewAlways  LintReview = "ALWAYS"
 	LintReviewWarning LintReview = "WARNING"
 	LintReviewError   LintReview = "ERROR"
+	maxSchemaMessageLength = 32768
 )
+
+func truncateSchemaMessage(message string) string {
+	if len(message) > maxSchemaMessageLength {
+		truncMsg := "... [truncated]"
+		return message[:maxSchemaMessageLength-len(truncMsg)] + truncMsg
+	}
+	return message
+}
 
 func init() {
 	SchemeBuilder.Register(&AtlasSchema{}, &AtlasSchemaList{})
@@ -211,7 +220,7 @@ func (sc *AtlasSchema) SetReconciling(message string) {
 		Type:    readyCond,
 		Status:  metav1.ConditionFalse,
 		Reason:  ReasonReconciling,
-		Message: message,
+		Message: truncateSchemaMessage(message),
 	})
 	sc.ResetFailed()
 }
@@ -233,7 +242,7 @@ func (sc *AtlasSchema) SetReady(status AtlasSchemaStatus, report any) {
 		Type:    readyCond,
 		Status:  metav1.ConditionTrue,
 		Reason:  ReasonApplied,
-		Message: msg,
+		Message: truncateSchemaMessage(msg),
 	})
 	sc.ResetFailed()
 }


### PR DESCRIPTION
The status.conditions.message field for atlasschema and atlasmigration custom resources has a max length of 32768 characters.  After successfully applying an update, the operator inserts the full query in the "Apply response" of the status.conditions.message as part of the reconciliation process.  If you have a large schema being applied, it could/will exceed this length, causing the atlasschema or atlasmigration resource to never actually show as complete / ready.  This fix truncates the length of the message field when necessary to allow it to work as intended.