### PR TITLE
feat: use specific seccomp for devdb

### DIFF
--- a/internal/controller/devdb.go
+++ b/internal/controller/devdb.go
@@ -198,6 +198,9 @@ func deploymentDevDB(key types.NamespacedName, targetURL url.URL) (*appsv1.Deplo
 		SecurityContext: &corev1.SecurityContext{
 			RunAsNonRoot:             ptr.To(true),
 			AllowPrivilegeEscalation: ptr.To(false),
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			},
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{"ALL"},
 			},


### PR DESCRIPTION
Will allow the operator and dev db:s to comply to strict security policies:

https://kyverno.io/policies/pod-security/restricted/restrict-seccomp-strict/restrict-seccomp-strict/

Fixes: https://github.com/ariga/atlas/issues/3518