### PR TITLE
ci: fix skaffold test

### DIFF
--- a/.github/workflows/cd-operator-release.yaml
+++ b/.github/workflows/cd-operator-release.yaml
@@ -20,30 +20,7 @@ on:
       - 'v*'
 jobs:
   helm-test:
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Create k8s Kind Cluster
-        uses: helm/kind-action@v1
-      - name: Install Skaffold
-        run: |
-          curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v2.16.1/skaffold-linux-amd64 && \
-          sudo install skaffold /usr/local/bin/
-      - name: Setup Helm
-        uses: azure/setup-helm@v4
-      - name: Run e2e tests with Operator
-        run: |
-          make test-e2e \
-            ATLAS_TOKEN=${{ secrets.ATLAS_TOKEN }} \
-            KIND_CLUSTER=chart-testing \
-            TEST_RUN='(schema|migration)-mysql'
-        env:
-          SKAFFOLD_PROFILE: helm
-      - name: test env vars
-        run: |
-          helm template atlas-operator charts/atlas-operator \
-            --set-json=extraEnvs='[{"name":"NORMAL_ENV","value":"value"}]' | grep NORMAL_ENV
+    uses: ./.github/workflows/ci-test-helm.yaml
   docker-build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-test-helm.yaml
+++ b/.github/workflows/ci-test-helm.yaml
@@ -1,0 +1,49 @@
+# Copyright 2025 The Atlas Operator Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: CI - Helm Test
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  push:
+    branches:
+      - "master"
+
+jobs:
+  helm-test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create k8s Kind Cluster
+        uses: helm/kind-action@v1
+      - name: Install Skaffold
+        run: |
+          curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v2.16.1/skaffold-linux-amd64 && \
+          sudo install skaffold /usr/local/bin/
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+      - name: Run e2e tests with Operator
+        run: |
+          make test-e2e \
+            ATLAS_TOKEN=${{ secrets.ATLAS_TOKEN }} \
+            KIND_CLUSTER=chart-testing \
+            TEST_RUN='(schema|migration)-mysql'
+        env:
+          SKAFFOLD_PROFILE: helm
+      - name: test env vars
+        run: |
+          helm template atlas-operator charts/atlas-operator \
+            --set-json=extraEnvs='[{"name":"NORMAL_ENV","value":"value"}]' | grep NORMAL_ENV

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -20,48 +20,39 @@ build:
   local:
     useBuildkit: true
   artifacts:
-    - image: controller
-      docker:
-        dockerfile: Dockerfile
-        buildArgs:
-          OPERATOR_VERSION: v0.0.1-local-k8s
+  - image: controller
+    docker:
+      dockerfile: Dockerfile
+      buildArgs:
+        OPERATOR_VERSION: v0.0.1-local-k8s
 profiles:
-  - name: kustomize
-    deploy:
-      kubectl:
-        flags:
-          apply: [ --server-side=true ]
-    manifests:
-      kustomize:
-        paths:
-          - config/default
-          - config/sqlserver
-          - config/customconfig
-  - name: helm
-    deploy:
-      kubectl:
-        flags:
-          apply: [ --server-side=true ]
-      helm:
-        releases:
-          - name: atlas-operator
-            chartPath: charts/atlas-operator
-            namespace: atlas-operator-system
-            createNamespace: true
-            setValues:
-              allowCustomConfig: true
-              image:
-                repository: controller
-                tag: v0.0.1-local-k8s
-              extraEnvs:
-                - name: MSSQL_ACCEPT_EULA
-                  value: "Y"
-                - name: MSSQL_PID
-                  value: "Developer"
-                - name: ATLAS_TOKEN
-                  valueFrom:
-                    secretKeyRef:
-                      key: ATLAS_TOKEN
-                      name: atlas-token-secret
-            valuesFiles:
-              - charts/atlas-operator/values.yaml
+- name: kustomize
+  deploy:
+    kubectl:
+      flags:
+        apply: [ --server-side=true ]
+  manifests:
+    kustomize:
+      paths:
+      - config/default
+      - config/sqlserver
+      - config/customconfig
+- name: helm
+  deploy:
+    helm:
+      releases:
+      - name: atlas-operator
+        chartPath: charts/atlas-operator
+        namespace: atlas-operator-system
+        createNamespace: true
+        setValues:
+          image:
+            repository: controller
+            tag: v0.0.1-local-k8s
+          extraEnvs:
+            - name: MSSQL_ACCEPT_EULA
+              value: "Y"
+            - name: MSSQL_PID
+              value: "Developer"
+        valuesFiles:
+        - charts/atlas-operator/values.yaml


### PR DESCRIPTION
This PR:
1. Attempts to fix the skaffold configuration to make the pre-release tests pass (can only be validated on master)
2. Separates the helm tests to a separate workflow file, with two puposes: to run these tests on each merge to master instead of just before the release, so if something breakes we can know sooner, and to allow running these tests manually on a branch.