### PR TITLE
Add support for Atlas CLI CE edition and add AllowDirty option

### DIFF
--- a/.github/workflows/cd-image-canary-release.yaml
+++ b/.github/workflows/cd-image-canary-release.yaml
@@ -19,6 +19,16 @@ on:
 jobs:
   push:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        edition: [enterprise, community]
+        include:
+          - edition: enterprise
+            atlas_image_suffix: ""
+            tag_suffix: ""
+          - edition: community
+            atlas_image_suffix: "-community"
+            tag_suffix: "-community"
     steps:
       - uses: actions/checkout@v2
       - name: Set up Docker Buildx
@@ -42,14 +52,15 @@ jobs:
         with:
           images: ${{ secrets.DOCKERHUB_USERNAME }}/atlas-operator
           tags: |
-            type=schedule
-            type=sha
-            type=ref,event=branch
-            type=semver,pattern={{version}}
+            type=schedule,suffix=${{ matrix.tag_suffix }}
+            type=sha,suffix=${{ matrix.tag_suffix }}
+            type=ref,event=branch,suffix=${{ matrix.tag_suffix }}
+            type=semver,pattern={{version}},suffix=${{ matrix.tag_suffix }}
           labels: |
             io.ariga.atlas.version=${{ steps.atlas.outputs.version }}
+            io.ariga.atlas.edition=${{ matrix.edition }}
             org.opencontainers.image.title=atlas-operator
-            org.opencontainers.image.description=Atlas Operator
+            org.opencontainers.image.description=Atlas Operator (${{ matrix.edition }} edition)
             org.opencontainers.image.url=https://atlasgo.io
             org.opencontainers.image.vendor=Ariga
             org.opencontainers.image.source=https://github.com/ariga/atlas-operator/blob/master/Dockerfile
@@ -59,6 +70,7 @@ jobs:
           context: .
           build-args: |
             ATLAS_VERSION=${{ steps.atlas.outputs.version }}
+            ATLAS_IMAGE=arigaio/atlas:${{ steps.atlas.outputs.version }}${{ matrix.atlas_image_suffix }}
             OPERATOR_VERSION=v${{ steps.meta.outputs.version }}
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/cd-operator-release.yaml
+++ b/.github/workflows/cd-operator-release.yaml
@@ -22,8 +22,18 @@ jobs:
   helm-test:
     uses: ./.github/workflows/ci-test-helm.yaml
   docker-build:
-    name: Build
+    name: Build (${{ matrix.edition }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        edition: [enterprise, community]
+        include:
+          - edition: enterprise
+            atlas_image_suffix: ""
+            tag_suffix: ""
+          - edition: community
+            atlas_image_suffix: "-community"
+            tag_suffix: "-community"
     steps:
       - uses: actions/checkout@v2
       - name: Set up Docker Buildx
@@ -47,11 +57,12 @@ jobs:
         with:
           images: ${{ secrets.DOCKERHUB_USERNAME }}/atlas-operator
           tags: |
-            type=semver,pattern={{version}},value=${{ github.ref_name }}
+            type=semver,pattern={{version}}${{ matrix.tag_suffix }},value=${{ github.ref_name }}
           labels: |
             io.ariga.atlas.version=${{ steps.atlas.outputs.version }}
+            io.ariga.atlas.edition=${{ matrix.edition }}
             org.opencontainers.image.title=atlas-operator
-            org.opencontainers.image.description=Atlas Operator
+            org.opencontainers.image.description=Atlas Operator (${{ matrix.edition }} edition)
             org.opencontainers.image.url=https://atlasgo.io
             org.opencontainers.image.vendor=Ariga
             org.opencontainers.image.source=https://github.com/ariga/atlas-operator/blob/master/Dockerfile
@@ -61,6 +72,7 @@ jobs:
           context: .
           build-args: |
             ATLAS_VERSION=${{ steps.atlas.outputs.version }}
+            ATLAS_IMAGE=arigaio/atlas:${{ steps.atlas.outputs.version }}${{ matrix.atlas_image_suffix }}
             OPERATOR_VERSION=${{ github.ref_name }}
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64

--- a/api/v1alpha1/atlasmigration_types.go
+++ b/api/v1alpha1/atlasmigration_types.go
@@ -91,6 +91,10 @@ type (
 		// BackoffLimit is the number of retries on error.
 		// +kubebuilder:default=20
 		BackoffLimit int `json:"backoffLimit,omitempty"`
+		// AllowDirty allows applying migrations to a database that has schemas
+		// not managed by Atlas (e.g., system schemas in TiDB).
+		// +optional
+		AllowDirty bool `json:"allowDirty,omitempty"`
 	}
 	CloudV0 struct {
 		URL       string    `json:"url,omitempty"`

--- a/internal/controller/atlasmigration_controller.go
+++ b/internal/controller/atlasmigration_controller.go
@@ -80,6 +80,7 @@ type (
 		Baseline        string
 		ExecOrder       string
 		MigrateDown     bool
+		AllowDirty      bool
 		ObservedHash    string
 		RemoteDir       *dbv1alpha1.Remote
 		Config          *hclwrite.File
@@ -381,7 +382,8 @@ func (r *AtlasMigrationReconciler) reconcile(ctx context.Context, data *migratio
 				TriggerType:    atlasexec.TriggerTypeKubernetes,
 				TriggerVersion: dbv1alpha1.VersionFromContext(ctx),
 			},
-			Vars: data.Vars,
+			Vars:       data.Vars,
+			AllowDirty: data.AllowDirty,
 		})
 		if err != nil {
 			return r.resultCLIErr(res, err, "Migrating")
@@ -437,6 +439,7 @@ func (r *AtlasMigrationReconciler) extractData(ctx context.Context, res *dbv1alp
 			Baseline:        s.Baseline,
 			ExecOrder:       string(s.ExecOrder),
 			MigrateDown:     false,
+			AllowDirty:      s.AllowDirty,
 		}
 	)
 	data.Config, err = s.GetConfig(ctx, r, res.Namespace)


### PR DESCRIPTION
The Atlas Operator didn't work with TiDB due to it using Atlas EE which does something with MySQL vector extensions and fails to do anything with TiDB. I tried to change Atlas Operator to use Atlas CE but encountered some issues. This PR fixes those and depends on changes to atlasexec from https://github.com/ariga/atlas/pull/3640 to communicate CE vs EE Atlas CLI differences (mainly lack of `atlas whoami`)

- Treat Atlas CE edition like non-logged in Atlas EE edition. Update couple places with that.
- Allow Dockerfile to build the operator with the Atlas CE CLI.
- Make CI jobs build both enterprise and community variants of the images.
- Adds AllowDirty option to enable working with TiDB which creates some tables itself and thus is automatically always considered Dirty by Atlas unless schema tries to replicate these tables but then we're encoding DB implementation details to schema which I don't like -> Add this option.