### PR TITLE
charts/atlas-operator: bump version and appVersion to 0.7.22

### DIFF
--- a/charts/atlas-operator/Chart.yaml
+++ b/charts/atlas-operator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: atlas-operator
 description: The Atlas Kubernetes Operator
 type: application
-version: 0.7.21
-appVersion: 0.7.21
+version: 0.7.22
+appVersion: 0.7.22


### PR DESCRIPTION
To include atlas-cli v1.1.1