### PR TITLE
cmd/main: support namespace-scoped watch

### DIFF
--- a/charts/atlas-operator/templates/deployment.yaml
+++ b/charts/atlas-operator/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
         {{- if or .Values.labelSelector .Values.watchNamespaces }}
         args:
         {{- with .Values.labelSelector }}
-        - --label-selector={{ . }}
+        - --label-selector={{ join "," . }}
         {{- end }}
         {{- with .Values.watchNamespaces }}
         - --namespace={{ join "," . }}

--- a/charts/atlas-operator/templates/deployment.yaml
+++ b/charts/atlas-operator/templates/deployment.yaml
@@ -53,9 +53,14 @@ spec:
       containers:
       - image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        {{- with .Values.labelSelector }}
+        {{- if or .Values.labelSelector .Values.watchNamespaces }}
         args:
+        {{- with .Values.labelSelector }}
         - --label-selector={{ . }}
+        {{- end }}
+        {{- with .Values.watchNamespaces }}
+        - --namespace={{ join "," . }}
+        {{- end }}
         {{- end }}
         livenessProbe:
           httpGet:

--- a/charts/atlas-operator/values.yaml
+++ b/charts/atlas-operator/values.yaml
@@ -65,10 +65,11 @@ prewarmDevDB: true
 allowCustomConfig: false
 
 # Restrict the operator to only manage AtlasSchema and AtlasMigration resources
-# matching this label selector (e.g. "app=foo" or "team in (a,b)").
-# Leave empty to manage all resources. This is useful when running multiple
-# operator instances in the same namespace, each handling specific resources.
-labelSelector: ""
+# matching these label selector requirements (ANDed together). Leave empty to
+# manage all resources. This is useful when running multiple operator instances
+# in the same namespace, each handling specific resources.
+# e.g. labelSelector: ["app=foo", "env in (prod,staging)"]
+labelSelector: []
 
 # Restrict the operator to only watch AtlasSchema and AtlasMigration resources
 # in these namespaces. Leave empty to watch all namespaces (cluster scope).

--- a/charts/atlas-operator/values.yaml
+++ b/charts/atlas-operator/values.yaml
@@ -70,6 +70,11 @@ allowCustomConfig: false
 # operator instances in the same namespace, each handling specific resources.
 labelSelector: ""
 
+# Restrict the operator to only watch AtlasSchema and AtlasMigration resources
+# in these namespaces. Leave empty to watch all namespaces (cluster scope).
+# e.g. watchNamespaces: ["team-a", "team-b"]
+watchNamespaces: []
+
 # -- Additional environment variables to set
 extraEnvs: []
 # extraEnvs:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -81,6 +82,7 @@ func main() {
 	var secureMetrics bool
 	var enableHTTP2 bool
 	var labelSelector string
+	var watchNamespaces string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -99,6 +101,10 @@ func main() {
 			"AtlasSchema and AtlasMigration resources the operator manages. When empty, all "+
 			"resources are managed. Use this to run multiple operator instances in the same "+
 			"namespace, each handling resources matching different labels.")
+	flag.StringVar(&watchNamespaces, "namespace", "",
+		"A comma-separated list of namespaces that restricts where the operator watches "+
+			"for AtlasSchema and AtlasMigration resources. When empty, the operator watches "+
+			"all namespaces (cluster scope).")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -107,13 +113,19 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
-	cacheOpts, err := cacheOptions(labelSelector)
+	namespaces := parseNamespaces(watchNamespaces)
+	cacheOpts, err := cacheOptions(labelSelector, namespaces)
 	if err != nil {
 		setupLog.Error(err, "invalid label selector", "selector", labelSelector)
 		os.Exit(1)
 	}
 	if labelSelector != "" {
 		setupLog.Info("restricting managed resources to label selector", "selector", labelSelector)
+	}
+	if len(namespaces) > 0 {
+		setupLog.Info("restricting watch to namespaces", "namespaces", namespaces)
+	} else {
+		setupLog.Info("watching all namespaces (cluster scope)")
 	}
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
@@ -207,29 +219,53 @@ func main() {
 	}
 }
 
-// cacheOptions builds the manager's cache options from the given label selector.
-// When the selector is empty, the returned options leave the cache unrestricted,
-// preserving the default behavior of managing every resource.
+// cacheOptions builds the manager's cache options from the given label selector
+// and the list of namespaces to watch.
 //
-// When set, only AtlasSchema and AtlasMigration resources matching the selector
-// are watched, cached, and therefore reconciled. This makes it possible to run
-// multiple operator instances in the same namespace, each owning a distinct set
-// of resources. Referenced ConfigMaps and Secrets are intentionally left
-// unfiltered, since they usually do not carry the operator's labels.
-func cacheOptions(labelSelector string) (cache.Options, error) {
+// When namespaces is empty, the operator watches all namespaces (cluster scope).
+// Otherwise the cache (and therefore the operator) is restricted to the given
+// namespaces, which also limits the referenced ConfigMaps and Secrets it reads.
+//
+// When labelSelector is set, only AtlasSchema and AtlasMigration resources
+// matching the selector are watched, cached, and therefore reconciled. This
+// makes it possible to run multiple operator instances side by side, each
+// owning a distinct set of resources. Referenced ConfigMaps and Secrets are
+// intentionally left unfiltered by label, since they usually do not carry the
+// operator's labels.
+func cacheOptions(labelSelector string, namespaces []string) (cache.Options, error) {
 	opts := cache.Options{}
-	if labelSelector == "" {
-		return opts, nil
+	if len(namespaces) > 0 {
+		opts.DefaultNamespaces = make(map[string]cache.Config, len(namespaces))
+		for _, ns := range namespaces {
+			opts.DefaultNamespaces[ns] = cache.Config{}
+		}
 	}
-	selector, err := labels.Parse(labelSelector)
-	if err != nil {
-		return opts, fmt.Errorf("parsing label selector %q: %w", labelSelector, err)
-	}
-	opts.ByObject = map[client.Object]cache.ByObject{
-		&dbv1alpha1.AtlasSchema{}:    {Label: selector},
-		&dbv1alpha1.AtlasMigration{}: {Label: selector},
+	if labelSelector != "" {
+		selector, err := labels.Parse(labelSelector)
+		if err != nil {
+			return opts, fmt.Errorf("parsing label selector %q: %w", labelSelector, err)
+		}
+		// Leaving ByObject.Namespaces nil lets controller-runtime default it
+		// from DefaultNamespaces, so the label filter and namespace scope are
+		// combined for the managed resources.
+		opts.ByObject = map[client.Object]cache.ByObject{
+			&dbv1alpha1.AtlasSchema{}:    {Label: selector},
+			&dbv1alpha1.AtlasMigration{}: {Label: selector},
+		}
 	}
 	return opts, nil
+}
+
+// parseNamespaces splits a comma-separated namespace list into a clean slice,
+// trimming whitespace and dropping empty entries.
+func parseNamespaces(s string) []string {
+	var out []string
+	for _, ns := range strings.Split(s, ",") {
+		if ns = strings.TrimSpace(ns); ns != "" {
+			out = append(out, ns)
+		}
+	}
+	return out
 }
 
 // checkForUpdate checks for version updates and security advisories for the Atlas Operator.

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -23,14 +23,16 @@ import (
 )
 
 func TestCacheOptions(t *testing.T) {
-	t.Run("empty selector leaves the cache unrestricted", func(t *testing.T) {
-		opts, err := cacheOptions("")
+	t.Run("no selector and no namespaces leaves the cache unrestricted", func(t *testing.T) {
+		opts, err := cacheOptions("", nil)
 		require.NoError(t, err)
 		require.Nil(t, opts.ByObject)
+		require.Nil(t, opts.DefaultNamespaces)
 	})
 	t.Run("valid selector restricts the managed resource types", func(t *testing.T) {
-		opts, err := cacheOptions("app=foo,env in (prod,staging)")
+		opts, err := cacheOptions("app=foo,env in (prod,staging)", nil)
 		require.NoError(t, err)
+		require.Nil(t, opts.DefaultNamespaces)
 		// Only AtlasSchema and AtlasMigration are filtered; Secrets and
 		// ConfigMaps stay unrestricted.
 		require.Len(t, opts.ByObject, 2)
@@ -47,8 +49,31 @@ func TestCacheOptions(t *testing.T) {
 			require.False(t, sel.Matches(labels.Set{"app": "bar", "env": "prod"}))
 		}
 	})
+	t.Run("namespaces restrict the watched namespaces", func(t *testing.T) {
+		opts, err := cacheOptions("", []string{"team-a", "team-b"})
+		require.NoError(t, err)
+		require.Nil(t, opts.ByObject)
+		require.Len(t, opts.DefaultNamespaces, 2)
+		require.Contains(t, opts.DefaultNamespaces, "team-a")
+		require.Contains(t, opts.DefaultNamespaces, "team-b")
+	})
+	t.Run("namespaces and selector can be combined", func(t *testing.T) {
+		opts, err := cacheOptions("team=a", []string{"team-a"})
+		require.NoError(t, err)
+		require.Len(t, opts.DefaultNamespaces, 1)
+		require.Contains(t, opts.DefaultNamespaces, "team-a")
+		require.Len(t, opts.ByObject, 2)
+	})
 	t.Run("invalid selector returns an error", func(t *testing.T) {
-		_, err := cacheOptions("app=foo,,,")
+		_, err := cacheOptions("app=foo,,,", nil)
 		require.Error(t, err)
 	})
+}
+
+func TestParseNamespaces(t *testing.T) {
+	require.Nil(t, parseNamespaces(""))
+	require.Nil(t, parseNamespaces("  , ,"))
+	require.Equal(t, []string{"a"}, parseNamespaces("a"))
+	require.Equal(t, []string{"a", "b"}, parseNamespaces("a,b"))
+	require.Equal(t, []string{"a", "b"}, parseNamespaces(" a , b , "))
 }

--- a/test/e2e/testscript/schema-label-selector.txtar
+++ b/test/e2e/testscript/schema-label-selector.txtar
@@ -45,7 +45,8 @@ image:
   tag: "${CONTROLLER_IMAGE_TAG}"
 crds:
   create: false
-labelSelector: "team=alpha"
+labelSelector:
+  - "team=alpha"
 -- schema-alpha.yaml --
 apiVersion: db.atlasgo.io/v1alpha1
 kind: AtlasSchema

--- a/test/e2e/testscript/schema-watch-namespace.txtar
+++ b/test/e2e/testscript/schema-watch-namespace.txtar
@@ -1,0 +1,73 @@
+# Verify the operator's --namespace support: an operator configured to watch a
+# specific namespace only processes AtlasSchema resources in that namespace.
+#
+# The default operator deployed by the harness watches all namespaces, so we
+# install a SECOND operator scoped to the test namespace via Helm and assert
+# through *its own* logs that it reconciles only the in-namespace resource.
+# Using in-memory SQLite means each operator applies the schema in its own
+# process with no shared state, so the two operators never interfere.
+
+# Render the values file for the scoped operator (expands ${NAMESPACE} and the
+# image env vars).
+cat scoped-values.yaml.tmpl > scoped-values.yaml
+
+# Install an operator scoped to the test namespace. crds.create=false because
+# the default operator already owns the CRDs in the cluster.
+helm install scoped ${CHART} -f scoped-values.yaml --wait --debug
+
+# Create a resource in the watched namespace...
+kubectl apply -f schema-in-scope.yaml
+
+# ...and one in a different namespace the scoped operator does not watch.
+exec kubectl create namespace ${NAMESPACE}-2
+exec kubectl apply -n ${NAMESPACE}-2 -f schema-out-scope.yaml
+
+# The scoped operator must reconcile the in-namespace resource...
+wait-log ${NAMESPACE} app.kubernetes.io/instance=scoped in-scope
+
+# ...while the default cluster-wide operator processes the out-of-namespace one,
+# proving "out-scope" is a valid resource that would be handled if it lived in a
+# watched namespace.
+wait-log ${CONTROLLER_NS} control-plane=controller-manager out-scope
+
+# Give the scoped operator extra time: if it were watching all namespaces it
+# would have logged "out-scope" by now (it has already reconciled "in-scope").
+exec sleep 15
+
+# Assert the scoped operator only ever saw the in-namespace resource.
+kubectl logs -l app.kubernetes.io/instance=scoped --tail=-1
+stdout 'in-scope'
+! stdout 'out-scope'
+
+# Clean up the scoped operator and the extra namespace.
+helm uninstall scoped --wait
+exec kubectl delete namespace ${NAMESPACE}-2
+
+-- scoped-values.yaml.tmpl --
+image:
+  repository: ${CONTROLLER_IMAGE_REPO}
+  tag: "${CONTROLLER_IMAGE_TAG}"
+crds:
+  create: false
+watchNamespaces:
+  - "${NAMESPACE}"
+-- schema-in-scope.yaml --
+apiVersion: db.atlasgo.io/v1alpha1
+kind: AtlasSchema
+metadata:
+  name: in-scope
+spec:
+  url: sqlite://file?mode=memory
+  schema:
+    sql: |
+      create table t_in_scope (id integer primary key);
+-- schema-out-scope.yaml --
+apiVersion: db.atlasgo.io/v1alpha1
+kind: AtlasSchema
+metadata:
+  name: out-scope
+spec:
+  url: sqlite://file?mode=memory
+  schema:
+    sql: |
+      create table t_out_scope (id integer primary key);


### PR DESCRIPTION
Add a --namespace flag (comma-separated) that restricts which namespaces the operator watches for AtlasSchema and AtlasMigration resources via the cache's DefaultNamespaces. Empty keeps the default cluster-wide scope, and it combines with the existing label selector. Wire it through the Helm chart as watchNamespaces.