### PR TITLE
internal/controller: run migrate status before spinning up a dev db

### DIFF
--- a/internal/controller/atlasmigration_controller.go
+++ b/internal/controller/atlasmigration_controller.go
@@ -264,13 +264,9 @@ func (r *AtlasMigrationReconciler) reconcile(ctx context.Context, res *dbv1alpha
 		return r.resultErr(res, err, dbv1alpha1.ReasonReadingMigrationData)
 	}
 
-	if err := s.devDB(ctx); err != nil {
-		if p, ok := errors.AsType[*pendingError](err); ok {
-			return r.resultPending(res, p.reason, p.message)
-		}
-		return r.resultErr(res, err, dbv1alpha1.ReasonGettingDevDB)
-	}
-
+	// Build the working directory and Atlas client without a dev database, so
+	// we can run `migrate status` first. When there are no pending migrations,
+	// the loop exits early and avoids the cost of spinning up a dev database.
 	if err := s.workingDir(ctx); err != nil {
 		return r.resultErr(res, err, dbv1alpha1.ReasonReadingMigrationData)
 	}
@@ -285,6 +281,10 @@ func (r *AtlasMigrationReconciler) reconcile(ctx context.Context, res *dbv1alpha
 
 	if err := s.whoAmI(ctx); err != nil {
 		return r.resultErr(res, err, dbv1alpha1.ReasonWhoAmI)
+	}
+
+	if err := s.migrateStatus(ctx); err != nil {
+		return r.resultErr(res, err, dbv1alpha1.ReasonMigrating)
 	}
 
 	if err := s.applyChanges(ctx); err != nil {
@@ -351,7 +351,9 @@ func (s *migrationRun) devDB(ctx context.Context) error {
 
 // workingDir creates a working directory for the Atlas CLI.
 // The working directory contains the atlas.hcl config
-// and the migrations directory (if any).
+// and the migrations directory (if any). At this point the config is rendered
+// without a dev database URL; prepareDevDB re-renders it once a dev database
+// is spun up.
 func (s *migrationRun) workingDir(context.Context) error {
 	wd, err := atlasexec.NewWorkingDir(
 		atlasexec.WithAtlasHCL(s.data.render),
@@ -399,25 +401,52 @@ func (s *migrationRun) whoAmI(ctx context.Context) error {
 	}
 }
 
-// applyChanges checks if there are any pending migration files,
-// then applies them, or migrates the database down when it is ahead
-// of the migration directory.
-func (s *migrationRun) applyChanges(ctx context.Context) error {
+// migrateStatus runs `migrate status` to check whether there are any pending
+// migration files. It does not require a dev database, so it can run before
+// one is created.
+func (s *migrationRun) migrateStatus(ctx context.Context) error {
 	s.log.Info("reconciling migration", "env", s.data.EnvName)
 	status, err := s.cli.MigrateStatus(ctx, &atlasexec.MigrateStatusParams{Env: s.data.EnvName, Vars: s.data.Vars})
 	if err != nil {
 		return err
 	}
 	s.status = status
-	switch {
+	return nil
+}
+
+// applyChanges applies the pending migration files on the target database, or
+// migrates the database down when it is ahead of the migration directory. When
+// there are no changes to apply, it marks the resource as ready without
+// spinning up a dev database.
+func (s *migrationRun) applyChanges(ctx context.Context) error {
+	switch status := s.status; {
 	case len(status.Pending) == 0 && len(status.Applied) > 0 && len(status.Available) < len(status.Applied):
+		if err := s.prepareDevDB(ctx); err != nil {
+			return err
+		}
 		return s.migrateDown(ctx)
 	case len(status.Pending) == 0:
 		s.noPendingChanges()
 		return nil
 	default:
+		if err := s.prepareDevDB(ctx); err != nil {
+			return err
+		}
 		return s.migrateApply(ctx)
 	}
+}
+
+// prepareDevDB spins up the dev database (when needed) and re-renders the
+// atlas.hcl config so it includes the dev database URL. This is deferred until
+// we know there is work to do, to avoid the cost of a dev database when there
+// are no pending migrations.
+func (s *migrationRun) prepareDevDB(ctx context.Context) error {
+	if err := s.devDB(ctx); err != nil {
+		return err
+	}
+	// Re-render atlas.hcl now that the dev database URL is known.
+	// "atlas.hcl" is the file name used by atlasexec.WithAtlasHCL.
+	return s.wd.CreateFile("atlas.hcl", s.data.render)
 }
 
 // migrateDown migrates the database down to the last available version.

--- a/internal/controller/atlasmigration_controller_test.go
+++ b/internal/controller/atlasmigration_controller_test.go
@@ -975,7 +975,7 @@ func TestAtlasMigrationReconciler_Credentials(t *testing.T) {
 	require.NoError(tt, err)
 	require.EqualValues(tt, reconcile.Result{}, c)
 	ev := tt.events()
-	require.Len(t, ev, 2)
+	require.Len(t, ev, 1)
 	require.Equal(t, "Normal Applied Version 20230412003626 applied", ev[0])
 }
 

--- a/internal/controller/devdb.go
+++ b/internal/controller/devdb.go
@@ -81,7 +81,12 @@ func (r *devDBReconciler) cleanUp(ctx context.Context, sc client.Object) {
 	if !r.prewarm {
 		deploy := &appsv1.Deployment{}
 		err := r.Get(ctx, key, deploy)
-		if err != nil {
+		switch {
+		case apierrors.IsNotFound(err):
+			// No dev database was created (e.g. there were no pending
+			// migrations), so there is nothing to clean up.
+			return
+		case err != nil:
 			r.recorder.Eventf(sc, corev1.EventTypeWarning, ReasonCleanUpDevDB, "Error getting devDB deployment: %v", err)
 			return
 		}

--- a/test/e2e/testscript/migration-skip-devdb.txtar
+++ b/test/e2e/testscript/migration-skip-devdb.txtar
@@ -1,0 +1,60 @@
+# This test verifies that the reconciliation loop runs `migrate status` before
+# spinning up a dev database, so that when there are no pending migrations the
+# loop exits early WITHOUT creating a dev database.
+db postgres:15.4 DB_URL
+kubectl create secret generic db-creds --from-literal=url=${DB_URL}
+
+# Wait for the first pod created
+kubectl-wait-available deploy/postgres
+# Wait for the DB ready before applying the migration
+kubectl-wait-ready -l app=postgres pods
+
+# Create configmap to store the migrations directory
+kubectl create configmap migration-dir --from-file=migrations
+
+# Phase 1: there are pending migrations, so the operator spins up a dev
+# database to apply them.
+kubectl apply -f migration.yaml
+kubectl-wait-ready AtlasMigration/pg
+kubectl wait --timeout=2h --for=jsonpath='{.status.lastAppliedVersion}'=20240101000000 AtlasMigration/pg
+
+# The dev database deployment was created to apply the pending migration.
+kubectl get deployment pg-atlas-dev-db
+
+# Phase 2: recreate the resource against a database that is already at the
+# latest version. `migrate status` reports no pending migrations, so the loop
+# marks the resource ready without ever spinning up a dev database.
+kubectl delete AtlasMigration/pg
+# Remove the dev database left over from phase 1 (also garbage-collected as an
+# owned resource) so we can assert it is not re-created.
+kubectl delete deployment pg-atlas-dev-db --ignore-not-found
+
+kubectl apply -f migration.yaml
+kubectl-wait-ready AtlasMigration/pg
+kubectl wait --timeout=2h --for=jsonpath='{.status.lastAppliedVersion}'=20240101000000 AtlasMigration/pg
+
+# No dev database was created this time, because there were no pending migrations.
+! kubectl get deployment pg-atlas-dev-db
+-- migrations/atlas.sum --
+h1:UqhsC3WJVK8Hkfk51x3ilg7+o//McxwfMErEBeMPzxY=
+20240101000000_init.sql h1:R2jO47qZUcfh/cPpbGx25druKi6FXDMhgqdTwufUO20=
+-- migrations/20240101000000_init.sql --
+-- Create "users" table
+CREATE TABLE "users" (
+  "id" integer NOT NULL,
+  "name" character varying NOT NULL,
+  PRIMARY KEY ("id")
+);
+-- migration.yaml --
+apiVersion: db.atlasgo.io/v1alpha1
+kind: AtlasMigration
+metadata:
+  name: pg
+spec:
+  dir:
+    configMapRef:
+      name: "migration-dir"
+  urlFrom:
+    secretKeyRef:
+      name: db-creds
+      key: url


### PR DESCRIPTION
Saves the time it takes to spin up a database and wait for it to become ready, in cases a migration is not needed