### PR TITLE
fix: make Secret informer conditional via WATCH_SECRETS env var

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -66,6 +66,12 @@ const (
 	prewarmDevDB = "PREWARM_DEVDB"
 	// allowCustomConfig when enabled it allows the use of custom config
 	allowsCustomConfig = "ALLOW_CUSTOM_CONFIG"
+	// watchSecrets when enabled it registers Secret informers so the controllers
+	// re-reconcile when referenced Secrets change. Requires RBAC permission to
+	// list/watch Secrets. Disable in environments that provide credentials through
+	// other means (e.g. file-based injection via OpenBao/Vault) and do not grant
+	// the operator Secret access.
+	envWatchSecrets = "WATCH_SECRETS"
 )
 
 func init() {
@@ -191,11 +197,15 @@ func main() {
 	}
 	prewarmDevDB := getPrewarmDevDBEnv()
 	allowCustomConfig := getAllowCustomConfigEnv()
+	watchSecrets := getWatchSecretsEnv()
 	// Setup controller for AtlasSchema
 	schemaController := controller.NewAtlasSchemaReconciler(mgr, prewarmDevDB)
 	schemaController.SetAtlasClient(controller.NewAtlasExec)
 	if allowCustomConfig {
 		schemaController.AllowCustomConfig()
+	}
+	if watchSecrets {
+		schemaController.WatchSecrets()
 	}
 	if err := schemaController.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AtlasSchema")
@@ -206,6 +216,9 @@ func main() {
 	migrationController.SetAtlasClient(controller.NewAtlasExec)
 	if allowCustomConfig {
 		migrationController.AllowCustomConfig()
+	}
+	if watchSecrets {
+		migrationController.WatchSecrets()
 	}
 	if err = migrationController.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AtlasMigration")
@@ -355,4 +368,19 @@ func getAllowCustomConfigEnv() bool {
 		os.Exit(1)
 	}
 	return allowsCustomConfig
+}
+
+// getWatchSecretsEnv returns the value of the env var WATCH_SECRETS.
+// if the env var is not set, it returns true (backwards compatible).
+func getWatchSecretsEnv() bool {
+	env := os.Getenv(envWatchSecrets)
+	if env == "" {
+		return true
+	}
+	watchSecrets, err := strconv.ParseBool(env)
+	if err != nil {
+		setupLog.Error(err, "invalid value for env var WATCH_SECRETS, expected true or false")
+		os.Exit(1)
+	}
+	return watchSecrets
 }

--- a/internal/controller/atlasmigration_controller.go
+++ b/internal/controller/atlasmigration_controller.go
@@ -68,6 +68,7 @@ type (
 		devDB            *devDBReconciler
 		// AllowCustomConfig allows the controller to use custom atlas.hcl config.
 		allowCustomConfig bool
+		watchSecrets      bool
 	}
 	// migrationData is the data used to render the HCL template
 	// that will be used for Atlas CLI
@@ -178,15 +179,25 @@ func (r *AtlasMigrationReconciler) storeDirState(ctx context.Context, obj client
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *AtlasMigrationReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
+	b := ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: runtime.NumCPU(),
 		}).
 		For(&dbv1alpha1.AtlasMigration{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&dbv1alpha1.AtlasMigration{}).
-		Watches(&corev1.Secret{}, r.secretWatcher).
-		Watches(&corev1.ConfigMap{}, r.configMapWatcher).
-		Complete(r)
+		Watches(&corev1.ConfigMap{}, r.configMapWatcher)
+	if r.watchSecrets {
+		b = b.Watches(&corev1.Secret{}, r.secretWatcher)
+	}
+	return b.Complete(r)
+}
+
+// WatchSecrets enables the Secret informer so the controller re-reconciles
+// when a referenced Secret changes. When disabled, the controller skips the
+// cluster-wide Secret LIST/WATCH, avoiding RBAC errors in environments that
+// provide credentials through other means (e.g. file-based injection).
+func (r *AtlasMigrationReconciler) WatchSecrets() {
+	r.watchSecrets = true
 }
 
 // SetAtlasClient sets the Atlas client for the reconciler.

--- a/internal/controller/atlasschema_controller.go
+++ b/internal/controller/atlasschema_controller.go
@@ -67,6 +67,7 @@ type (
 		devDB            *devDBReconciler
 		// AllowCustomConfig allows the controller to use custom atlas.hcl config.
 		allowCustomConfig bool
+		watchSecrets      bool
 	}
 	// managedData contains information about the managed database and its desired state.
 	managedData struct {
@@ -453,15 +454,25 @@ func (r *AtlasSchemaReconciler) schemaApply(
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *AtlasSchemaReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
+	b := ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: runtime.NumCPU(),
 		}).
 		For(&dbv1alpha1.AtlasSchema{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&dbv1alpha1.AtlasSchema{}).
-		Watches(&corev1.ConfigMap{}, r.configMapWatcher).
-		Watches(&corev1.Secret{}, r.secretWatcher).
-		Complete(r)
+		Watches(&corev1.ConfigMap{}, r.configMapWatcher)
+	if r.watchSecrets {
+		b = b.Watches(&corev1.Secret{}, r.secretWatcher)
+	}
+	return b.Complete(r)
+}
+
+// WatchSecrets enables the Secret informer so the controller re-reconciles
+// when a referenced Secret changes. When disabled, the controller skips the
+// cluster-wide Secret LIST/WATCH, avoiding RBAC errors in environments that
+// provide credentials through other means (e.g. file-based injection).
+func (r *AtlasSchemaReconciler) WatchSecrets() {
+	r.watchSecrets = true
 }
 
 func (r *AtlasSchemaReconciler) watchRefs(res *dbv1alpha1.AtlasSchema) {


### PR DESCRIPTION
The Secret watch registered in SetupWithManager() is unconditional, causing the operator to fail when RBAC does not grant Secret access (e.g. when rbac.clusterWideSecretAccess is false). The shared controller-runtime cache refuses to sync when any single informer fails, which prevents all controllers from starting — even when no CR references a secretKeyRef.

Add a WATCH_SECRETS env var (default: true) that gates the Watches(&corev1.Secret{}) call. When set to false, the Secret informer is skipped entirely, allowing the operator to start and reconcile resources that use alternative credential injection (e.g. file-based via OpenBao/Vault).