### PR TITLE
fix: keep Secrets out of the cache when WATCH_SECRETS is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ To configure the operator, you can set the following values in the `values.yaml`
 
 - `prewarmDevDB`: The Operator always keeps devdb resources around to speed up the migration process. Set this to `false` to disable this feature.
 
+- `watchSecrets`: The Operator watches the Secrets referenced by `AtlasSchema` and `AtlasMigration` resources, so that rotating one triggers a reconcile of the resources that use it. This requires `list` and `watch` on secrets in every watched namespace. Set this to `false` to read Secrets directly from the API server instead, which requires only `get` on the Secret being read; referenced Secrets are still read on every reconcile, but rotating one no longer triggers a reconcile on its own. Defaults to the value of `rbac.clusterWideSecretAccess`.
+
+  Note that `AtlasMigration` stores the state of a `local` or `configMapRef` migration directory in a Secret it owns, so the Operator needs `get`, `create` and `update` on secrets in the namespaces it manages regardless of this setting.
+
 - `allowCustomConfig`: Enable this to allow custom `atlas.hcl` configuration. To use this feature, you can set the `config` field in the `AtlasSchema` or `AtlasMigration` resource.
 
 ```yaml

--- a/charts/atlas-operator/Chart.yaml
+++ b/charts/atlas-operator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: atlas-operator
 description: The Atlas Kubernetes Operator
 type: application
-version: 0.7.48
-appVersion: 0.7.48
+version: 0.7.49
+appVersion: 0.7.49

--- a/charts/atlas-operator/templates/_helpers.tpl
+++ b/charts/atlas-operator/templates/_helpers.tpl
@@ -68,3 +68,19 @@ Create the name of the service account to use
 {{- define "atlas-operator.leaderElectionRole" -}}
 {{ include "atlas-operator.fullname" . }}-leader-election-role
 {{- end }}
+
+{{/*
+Whether the operator watches the Secrets it references (WATCH_SECRETS).
+
+Defaults to rbac.clusterWideSecretAccess so that dropping the `secrets` rule from
+the ClusterRole cannot leave the operator waiting on a Secret watch it is not
+allowed to open. Set `watchSecrets` explicitly to override, for example when RBAC
+is managed outside this chart.
+*/}}
+{{- define "atlas-operator.watchSecrets" -}}
+{{- if kindIs "invalid" .Values.watchSecrets -}}
+{{- .Values.rbac.clusterWideSecretAccess -}}
+{{- else -}}
+{{- .Values.watchSecrets -}}
+{{- end -}}
+{{- end }}

--- a/charts/atlas-operator/templates/deployment.yaml
+++ b/charts/atlas-operator/templates/deployment.yaml
@@ -88,6 +88,8 @@ spec:
           value: "{{ .Values.prewarmDevDB }}"
         - name: ALLOW_CUSTOM_CONFIG
           value: "{{ .Values.allowCustomConfig }}"
+        - name: WATCH_SECRETS
+          value: "{{ include "atlas-operator.watchSecrets" . }}"
         {{- if .Values.persistence.enabled }}
         - name: DATA_DIR
           value: {{ .Values.persistence.mountPath | quote }}

--- a/charts/atlas-operator/values.yaml
+++ b/charts/atlas-operator/values.yaml
@@ -15,6 +15,11 @@ rbac:
   # Remove secrets from the operator ClusterRole.
   # Disable when credentials are provided via extraEnvs or external injection
   # and the operator does not need to resolve Secret references.
+  # This also turns off the Secret watch, see `watchSecrets` below.
+  # Note that AtlasMigration stores the state of a `local` or `configMapRef`
+  # migration directory in a Secret it owns, so the operator still needs
+  # get/create/update on secrets in the namespaces it manages. Grant that with
+  # your own (namespaced) Role when disabling this.
   clusterWideSecretAccess: true
 
 crds:
@@ -67,6 +72,16 @@ prewarmDevDB: true
 # Warning: This setting enables users to use the `external` and `sql` data sources
 # which can be used to execute arbitrary commands and queries. Use with caution.
 allowCustomConfig: false
+
+# Watch the Secrets referenced by AtlasSchema and AtlasMigration resources, so that
+# changing one triggers a reconcile of the resources that use it. This requires
+# `list` and `watch` on secrets in every watched namespace.
+# Set to false to read Secrets directly from the API server instead, which requires
+# only `get` on the Secret being read. Referenced Secrets are still read on every
+# reconcile, but rotating one no longer triggers a reconcile on its own.
+# Defaults to `rbac.clusterWideSecretAccess`. Set it explicitly to override, for
+# example when RBAC is managed outside this chart.
+watchSecrets: ~
 
 # Restrict the operator to only manage AtlasSchema and AtlasMigration resources
 # matching these label selector requirements (ANDed together). Leave empty to

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,6 +31,7 @@ import (
 
 	"ariga.io/atlas/atlasexec"
 	"golang.org/x/mod/semver"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -66,11 +67,21 @@ const (
 	prewarmDevDB = "PREWARM_DEVDB"
 	// allowCustomConfig when enabled it allows the use of custom config
 	allowsCustomConfig = "ALLOW_CUSTOM_CONFIG"
-	// watchSecrets when enabled it registers Secret informers so the controllers
-	// re-reconcile when referenced Secrets change. Requires RBAC permission to
-	// list/watch Secrets. Disable in environments that provide credentials through
-	// other means (e.g. file-based injection via OpenBao/Vault) and do not grant
-	// the operator Secret access.
+	// envWatchSecrets when enabled (the default) the controllers watch the Secrets
+	// they reference and re-reconcile when one changes. Secret reads are then served
+	// from the shared cache, which requires list/watch on Secrets across every
+	// namespace the operator watches.
+	//
+	// When disabled, no Secret informer is created and every Secret read is a live
+	// API call, which needs only "get" on the Secret being read. Referenced Secrets
+	// are still read at their current value on each reconcile, but a change to one
+	// no longer triggers a reconcile on its own. Disable it in environments that
+	// provide credentials through other means (e.g. file-based injection via
+	// OpenBao/Vault) or that only grant the operator namespaced Secret access.
+	//
+	// Note that AtlasMigration stores the state of a local or ConfigMap migration
+	// directory in a Secret it owns, so it needs get/create/update on Secrets in the
+	// namespaces it manages regardless of this setting.
 	envWatchSecrets = "WATCH_SECRETS"
 )
 
@@ -160,6 +171,21 @@ func main() {
 		TLSOpts: tlsOpts,
 	})
 
+	watchSecrets := getWatchSecretsEnv()
+	clientOpts := client.Options{}
+	if !watchSecrets {
+		// Skipping the Watches() call alone does not keep the operator away from
+		// Secrets: the cache-backed client lazily creates and starts that same
+		// informer on the first Get, re-issuing the LIST/WATCH we meant to avoid
+		// and then blocking the reconcile worker in WaitForCacheSync until the
+		// manager shuts down. Take Secrets out of the cache so every read is a
+		// live lookup that fails fast when it is not permitted.
+		clientOpts.Cache = &client.CacheOptions{
+			DisableFor: []client.Object{&corev1.Secret{}},
+		}
+		setupLog.Info("secret watching is disabled, reading secrets directly from the API server")
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
 		// Attach the operator and atlas versions to the manager's base logger so
@@ -167,6 +193,7 @@ func main() {
 		// log (logger "events", derived via options.Logger.WithName("events")).
 		Logger: ctrl.Log.WithValues("operator", version, "atlas", atlasVer),
 		Cache:  cacheOpts,
+		Client: clientOpts,
 		Metrics: server.Options{
 			BindAddress:   metricsAddr,
 			SecureServing: secureMetrics,
@@ -197,7 +224,6 @@ func main() {
 	}
 	prewarmDevDB := getPrewarmDevDBEnv()
 	allowCustomConfig := getAllowCustomConfigEnv()
-	watchSecrets := getWatchSecretsEnv()
 	// Setup controller for AtlasSchema
 	schemaController := controller.NewAtlasSchemaReconciler(mgr, prewarmDevDB)
 	schemaController.SetAtlasClient(controller.NewAtlasExec)

--- a/internal/controller/atlasmigration_controller.go
+++ b/internal/controller/atlasmigration_controller.go
@@ -192,10 +192,18 @@ func (r *AtlasMigrationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return b.Complete(r)
 }
 
-// WatchSecrets enables the Secret informer so the controller re-reconciles
-// when a referenced Secret changes. When disabled, the controller skips the
-// cluster-wide Secret LIST/WATCH, avoiding RBAC errors in environments that
-// provide credentials through other means (e.g. file-based injection).
+// WatchSecrets registers a Secret event handler so the controller re-reconciles
+// when a referenced Secret changes. It requires list/watch on Secrets in every
+// namespace the operator watches.
+//
+// When it is not called, the caller must also keep Secrets out of the manager's
+// cache (client.CacheOptions.DisableFor), otherwise the cache-backed client
+// re-creates this informer on the first Secret read and blocks on it. See
+// WATCH_SECRETS in cmd/main.go.
+//
+// Either way the controller reads, creates and updates the Secret that holds the
+// state of a local or ConfigMap migration directory, so it always needs
+// get/create/update on Secrets in the namespaces it manages.
 func (r *AtlasMigrationReconciler) WatchSecrets() {
 	r.watchSecrets = true
 }

--- a/internal/controller/atlasschema_controller.go
+++ b/internal/controller/atlasschema_controller.go
@@ -467,10 +467,14 @@ func (r *AtlasSchemaReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return b.Complete(r)
 }
 
-// WatchSecrets enables the Secret informer so the controller re-reconciles
-// when a referenced Secret changes. When disabled, the controller skips the
-// cluster-wide Secret LIST/WATCH, avoiding RBAC errors in environments that
-// provide credentials through other means (e.g. file-based injection).
+// WatchSecrets registers a Secret event handler so the controller re-reconciles
+// when a referenced Secret changes. It requires list/watch on Secrets in every
+// namespace the operator watches.
+//
+// When it is not called, the caller must also keep Secrets out of the manager's
+// cache (client.CacheOptions.DisableFor), otherwise the cache-backed client
+// re-creates this informer on the first Secret read and blocks on it. See
+// WATCH_SECRETS in cmd/main.go.
 func (r *AtlasSchemaReconciler) WatchSecrets() {
 	r.watchSecrets = true
 }


### PR DESCRIPTION
Skipping the Watches() call alone did not stop the Secret LIST/WATCH: the cache-backed client re-created the informer on the first Get and then blocked the reconcile worker in WaitForCacheSync. Disable the Secret cache so reads are live lookups that need only `get`.

Render WATCH_SECRETS from a new `watchSecrets` chart value defaulting to `rbac.clusterWideSecretAccess`, so that toggle no longer crash-loops on its own, and correct the docs that claimed Secret access could be revoked.